### PR TITLE
🐛 Persist parallel split gateway before branch executions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/engine/handler/parallel_gateway_handler.ts
+++ b/src/runtime/engine/handler/parallel_gateway_handler.ts
@@ -64,6 +64,10 @@ export class ParallelGatewayHandler extends FlowNodeHandler<Model.Gateways.Paral
       // first find the ParallelGateway that joins the branch back to the original branch
       const joinGateway: Model.Gateways.ParallelGateway = processModelFacade.getJoinGatewayFor(flowNode);
 
+      // The state change must be peformed before starting to execute the parallel branches.
+      // Otherwise, the Split gateay will be in a "running" state until every parallel branch has finished execution.
+      await this.flowNodeInstanceService.persistOnExit(flowNode.id, this.flowNodeInstanceId, token);
+
       // all parallel branches are only executed until the join gateway is reached
       const parallelBranchExecutionPromises: Array<Promise<NextFlowNodeInfo>> =
         this._executeParallelBranches(outgoingSequenceFlows, joinGateway, token, processTokenFacade, processModelFacade, executionContextFacade);
@@ -74,8 +78,6 @@ export class ParallelGatewayHandler extends FlowNodeHandler<Model.Gateways.Paral
       for (const nextFlowNodeInfo of nextFlowNodeInfos) {
         processTokenFacade.mergeTokenHistory(nextFlowNodeInfo.processTokenFacade);
       }
-
-      const nextFlowNode: Model.Base.FlowNode = await processModelFacade.getNextFlowNodeFor(joinGateway);
 
       const processTerminationSubscriptionIsActive: boolean = processTerminationSubscription !== undefined;
       if (processTerminationSubscriptionIsActive) {
@@ -88,12 +90,14 @@ export class ParallelGatewayHandler extends FlowNodeHandler<Model.Gateways.Paral
         return new NextFlowNodeInfo(undefined, token, processTokenFacade);
       }
 
-      await this.flowNodeInstanceService.persistOnExit(flowNode.id, this.flowNodeInstanceId, token);
-
-      return new NextFlowNodeInfo(nextFlowNode, token, processTokenFacade);
-    } else {
-      return undefined;
+      return new NextFlowNodeInfo(joinGateway, token, processTokenFacade);
     }
+
+    const nextFlowNode: Model.Base.FlowNode = await processModelFacade.getNextFlowNodeFor(flowNode);
+
+    await this.flowNodeInstanceService.persistOnExit(flowNode.id, this.flowNodeInstanceId, token);
+
+    return new NextFlowNodeInfo(nextFlowNode, token, processTokenFacade);
   }
 
   private _createProcessTerminationSubscription(processInstanceId: string): ISubscription {


### PR DESCRIPTION
**Changes:**

1. Change `ParallelSplitGateway` state to 'finished', before the parallel branches get executed
2. Use the corresponding `ParallelJoinGateway` as the next flow node to run, instead of the FlowNode that follows the Join Gateway.

**Issues:**

Closes #171

PR: #172

## How can others test the changes?

- Run a process that uses ParallelGateways
- Best use parallel running branches with at least one UserTask
- When the parallel branches get run, the status of the ParallelSplitGateway should be `finished`

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️     |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️     |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
