### PR TITLE
🐛 Fix parsing of ProcessModels with empty lanes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/model/parser/process_lane_set_parser.ts
+++ b/src/model/parser/process_lane_set_parser.ts
@@ -32,8 +32,8 @@ export function parseProcessLaneSet(data: any): Model.Types.LaneSet {
 
     const flowNodeReferences: Array<string> = getModelPropertyAsArray(laneRaw, BpmnTags.LaneProperty.FlowNodeRef);
 
-    const flowNodeReferenceUndefined: boolean = flowNodeReferences === undefined;
-    if (flowNodeReferenceUndefined) {
+    const laneHasNoFlowNodes: boolean = flowNodeReferences === undefined || flowNodeReferences.length === 0;
+    if (laneHasNoFlowNodes) {
       return laneSet;
     }
 

--- a/src/model/parser/process_lane_set_parser.ts
+++ b/src/model/parser/process_lane_set_parser.ts
@@ -15,6 +15,7 @@ export function parseProcessLaneSet(data: any): Model.Types.LaneSet {
   const lanesRaw: Array<any> = getModelPropertyAsArray(laneSetData, BpmnTags.Lane.Lane);
 
   const laneSet: Model.Types.LaneSet = new Model.Types.LaneSet();
+  laneSet.lanes = [];
 
   if (!lanesRaw) {
     return laneSet;
@@ -30,6 +31,12 @@ export function parseProcessLaneSet(data: any): Model.Types.LaneSet {
     };
 
     const flowNodeReferences: Array<string> = getModelPropertyAsArray(laneRaw, BpmnTags.LaneProperty.FlowNodeRef);
+
+    const flowNodeReferenceUndefined: boolean = flowNodeReferences === undefined;
+    if (flowNodeReferenceUndefined) {
+      return laneSet;
+    }
+
     const trimmedFlowNodeReferences: Array<string> = flowNodeReferences.map(flowNodeReferenceTrimmer);
     lane.flowNodeReferences = trimmedFlowNodeReferences;
 


### PR DESCRIPTION
**Changes:**

Parsing a ProcessModel with an empty lane resulted in an internal error.

With this PR, such lanes will be parsed as empty instead.

PR: #185 

## How can others test the changes?

Try importing a ProcessModel with an empty lane.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Fixing Security Issues   | `:lock:`             | 🔒     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️      |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️      |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
