### PR TITLE
✨Resume process

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -76,7 +76,6 @@ function registerServices(container) {
   container
     .register('ResumeProcessService', ResumeProcessService)
     .dependencies(
-      'CorrelationService',
       'EventAggregator',
       'FlowNodeHandlerFactory',
       'FlowNodeInstanceService',

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -222,13 +222,11 @@ function registerHandlers(container) {
 
   container
     .register('SubProcessHandler', SubProcessHandler)
-    .dependencies('CorrelationService',
-                  'EventAggregator',
+    .dependencies('EventAggregator',
                   'FlowNodeHandlerFactory',
                   'FlowNodeInstanceService',
                   'LoggingApiService',
-                  'MetricsApiService',
-                  'ResumeProcessService');
+                  'MetricsApiService');
 
   container
     .register('TimerBoundaryEventHandler', TimerBoundaryEventHandler)

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -223,8 +223,7 @@ function registerHandlers(container) {
 
   container
     .register('SubProcessHandler', SubProcessHandler)
-    .dependencies('CorrelationService',
-                  'EventAggregator',
+    .dependencies('EventAggregator',
                   'FlowNodeHandlerFactory',
                   'FlowNodeInstanceService',
                   'LoggingApiService',

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -223,7 +223,8 @@ function registerHandlers(container) {
 
   container
     .register('SubProcessHandler', SubProcessHandler)
-    .dependencies('EventAggregator',
+    .dependencies('CorrelationService',
+                  'EventAggregator',
                   'FlowNodeHandlerFactory',
                   'FlowNodeInstanceService',
                   'LoggingApiService',

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "@types/clone": "~0.1.30",
     "addict-ioc": "~2.5.1",
     "bluebird": "~3.5.2",
-    "clone": "2.1.2",
-    "loggerhythm": "3.0.3",
-    "mocha": "5.2.0",
-    "moment": "2.22.2",
-    "uuid": "3.3.2",
-    "should": "13.2.3",
-    "xml2js": "0.4.19"
+    "clone": "~2.1.2",
+    "loggerhythm": "~3.0.3",
+    "mocha": "~5.2.0",
+    "moment": "~2.22.2",
+    "uuid": "~3.3.2",
+    "should": "~13.2.3",
+    "xml2js": "~0.4.19"
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@process-engine/consumer_api_contracts": "~1.3.0",
     "@process-engine/logging_api_contracts": "~0.3.0",
     "@process-engine/metrics_api_contracts": "~0.3.0",
-    "@process-engine/process_engine_contracts": "feature~resume_process",
+    "@process-engine/process_engine_contracts": "~35.0.0",
     "@types/clone": "~0.1.30",
     "addict-ioc": "~2.5.1",
     "bluebird": "~3.5.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "7.6.0",
+  "version": "8.0.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/engine/execute_process_service.ts
+++ b/src/runtime/engine/execute_process_service.ts
@@ -1,4 +1,3 @@
-import {Logger} from 'loggerhythm';
 import * as moment from 'moment';
 import * as uuid from 'uuid';
 
@@ -22,7 +21,6 @@ import {
   IProcessTokenResult,
   Model,
   NextFlowNodeInfo,
-  ProcessStartedMessage,
   Runtime,
   TerminateEndEventReachedMessage,
 } from '@process-engine/process_engine_contracts';

--- a/src/runtime/engine/execute_process_service.ts
+++ b/src/runtime/engine/execute_process_service.ts
@@ -350,10 +350,8 @@ export class ExecuteProcessService implements IExecuteProcessService {
   /**
    * Writes logs and metrics at the beginning of a ProcessInstance's execution.
    *
-   * @param correlationId     The ID of the Correlation the ProcessInstance
-   *                          belongs to.
-   * @param processModelId    The ID of the ProcessModel describing the
-   *                          ProcessInstance.
+   * @param correlationId     The ProcessInstance's CorrelationId.
+   * @param processModelId    The ProcessInstance's ProcessModelId.
    * @param processInstanceId The ID of the ProcessInstance.
    */
   private _logProcessStarted(correlationId: string, processModelId: string, processInstanceId: string): void {
@@ -374,10 +372,8 @@ export class ExecuteProcessService implements IExecuteProcessService {
   /**
    * Writes logs and metrics after a ProcessInstance finishes execution.
    *
-   * @param correlationId     The ID of the Correlation the ProcessInstance
-   *                          belongs to.
-   * @param processModelId    The ID of the ProcessModel describing the
-   *                          ProcessInstance.
+   * @param correlationId     The ProcessInstance's CorrelationId.
+   * @param processModelId    The ProcessInstance's ProcessModelId.
    * @param processInstanceId The ID of the ProcessInstance.
    */
   private _logProcessFinished(correlationId: string, processModelId: string, processInstanceId: string): void {
@@ -397,10 +393,8 @@ export class ExecuteProcessService implements IExecuteProcessService {
   /**
    * Writes logs and metrics when a ProcessInstances was interrupted by an error.
    *
-   * @param correlationId     The ID of the Correlation the ProcessInstance
-   *                          belongs to.
-   * @param processModelId    The ID of the ProcessModel describing the
-   *                          ProcessInstance.
+   * @param correlationId     The ProcessInstance's CorrelationId.
+   * @param processModelId    The ProcessInstance's ProcessModelId.
    * @param processInstanceId The ID of the ProcessInstance.
    */
   private _logProcessError(correlationId: string, processModelId: string, processInstanceId: string, error: Error): void {

--- a/src/runtime/engine/execute_process_service.ts
+++ b/src/runtime/engine/execute_process_service.ts
@@ -267,7 +267,7 @@ export class ExecuteProcessService implements IExecuteProcessService {
       processTerminationSubscription.dispose();
     }
 
-    return resultToken;
+    return resultToken.result;
   }
 
   /**

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
@@ -79,7 +79,7 @@ export class MessageBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bo
 
     return new Promise<NextFlowNodeInfo>(async(resolve: Function): Promise<void> => {
 
-      const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
+      const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
       try {
         this._subscribeToMessageEvent(resolve, onEnterToken, processTokenFacade, processModelFacade);
@@ -118,13 +118,11 @@ export class MessageBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bo
       }
       this.messageReceived = true;
 
-      processTokenFacade.addResultForFlowNode(this.messageBoundaryEvent.id, message.currentToken);
       token.payload = message.currentToken;
 
       // if the message was received before the decorated handler finished execution,
       // the MessageBoundaryEvent will be used to determine the next FlowNode to execute
-      const oldTokenFormat: any = await processTokenFacade.getOldTokenFormat();
-      await processTokenFacade.addResultForFlowNode(this.messageBoundaryEvent.id, oldTokenFormat.current);
+      await processTokenFacade.addResultForFlowNode(this.messageBoundaryEvent.id, token.payload);
 
       const nextNodeAfterBoundaryEvent: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.messageBoundaryEvent);
 

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
@@ -118,13 +118,11 @@ export class SignalBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bou
       }
       this.signalReceived = true;
 
-      processTokenFacade.addResultForFlowNode(this.signalBoundaryEvent.id, signal.currentToken);
       token.payload = signal.currentToken;
 
       // if the signal was received before the decorated handler finished execution,
       // the signalBoundaryEvent will be used to determine the next FlowNode to execute
-      const oldTokenFormat: any = await processTokenFacade.getOldTokenFormat();
-      await processTokenFacade.addResultForFlowNode(this.signalBoundaryEvent.id, oldTokenFormat.current);
+      await processTokenFacade.addResultForFlowNode(this.signalBoundaryEvent.id, token.payload);
 
       const nextNodeAfterBoundaryEvent: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.signalBoundaryEvent);
 

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -17,8 +17,6 @@ import {
 import {Logger} from 'loggerhythm';
 import {FlowNodeHandler} from '../index';
 
-const logger: Logger = Logger.createLogger('processengine:runtime:timer_boundary_event');
-
 export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
 
   private _decoratedHandler: FlowNodeHandler<Model.Base.FlowNode>;
@@ -33,6 +31,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
     super(flowNodeInstanceService, loggingApiService, metricsService, timerBoundaryEventModel);
     this._decoratedHandler = decoratedHandler;
     this._timerFacade = timerFacade;
+    this.logger = Logger.createLogger(`processengine:runtime:timer_boundary_event:${timerBoundaryEventModel.id}`);
   }
 
   private get timerBoundaryEvent(): Model.Events.BoundaryEvent {
@@ -166,7 +165,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
       return evaluateFunction.call(tokenData, tokenData);
 
     } catch (err) {
-      logger.error(err);
+      this.logger.error(err);
       throw err;
     }
   }

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -127,7 +127,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
           resolve(new NextFlowNodeInfo(nextNodeAfterBoundaryEvent, onEnterToken, processTokenFacade));
         };
 
-        timerSubscription = await this._timerFacade.initializeTimer(this.timerBoundaryEvent, timerType, timerValue, timerElapsed);
+        timerSubscription = this._timerFacade.initializeTimer(this.timerBoundaryEvent, timerType, timerValue, timerElapsed);
 
         const nextFlowNodeInfo: NextFlowNodeInfo =
           await this._decoratedHandler.resume(flowNodeInstance, processTokenFacade, processModelFacade, identity);

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -65,8 +65,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
 
           // if the timer elapsed before the decorated handler finished execution,
           // the TimerBoundaryEvent will be used to determine the next FlowNode to execute
-          const oldTokenFormat: any = await processTokenFacade.getOldTokenFormat();
-          await processTokenFacade.addResultForFlowNode(this.timerBoundaryEvent.id, oldTokenFormat.current);
+          await processTokenFacade.addResultForFlowNode(this.timerBoundaryEvent.id, token.payload);
 
           const nextNodeAfterBoundaryEvent: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.timerBoundaryEvent);
           resolve(new NextFlowNodeInfo(nextNodeAfterBoundaryEvent, token, processTokenFacade));
@@ -102,7 +101,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
 
     return new Promise<NextFlowNodeInfo> (async(resolve: Function, reject: Function): Promise<NextFlowNodeInfo> => {
 
-      const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
+      const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
       let timerSubscription: ISubscription;
 
@@ -122,8 +121,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
 
           // if the timer elapsed before the decorated handler finished resumption,
           // the TimerBoundaryEvent will be used to determine the next FlowNode to execute
-          const oldTokenFormat: any = await processTokenFacade.getOldTokenFormat();
-          await processTokenFacade.addResultForFlowNode(this.timerBoundaryEvent.id, oldTokenFormat.current);
+          await processTokenFacade.addResultForFlowNode(this.timerBoundaryEvent.id, onEnterToken.payload);
 
           const nextNodeAfterBoundaryEvent: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.timerBoundaryEvent);
           resolve(new NextFlowNodeInfo(nextNodeAfterBoundaryEvent, onEnterToken, processTokenFacade));

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -101,28 +101,12 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
     }
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onSuspended" state.
-   *
-   * When the FlowNodeInstance was interrupted during this stage, we need to
-   * run the handler again, except for the "onSuspend" state change.
-   *
-   * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
-   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
-   *                             suspended.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @param   identity           The requesting user's identity.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                      onSuspendToken: Runtime.Types.ProcessToken,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                      identity: IIdentity,
-                                     ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                        identity: IIdentity,
+                                      ): Promise<NextFlowNodeInfo> {
 
     // First we need to find out if the Subprocess was already started.
     const correlation: Runtime.Types.Correlation
@@ -157,23 +141,10 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
     return this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onResumed" state.
-   *
-   * Basically, the handler had already finished.
-   * The final result is only missing in the database.
-   *
-   * @async
-   * @param   resumeToken   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                     processTokenFacade: IProcessTokenFacade,
-                                     processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.callActivity.id, resumeToken.payload);
     await this.persistOnExit(resumeToken);

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -114,7 +114,7 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
 
     const matchingSubProcess: Runtime.Types.CorrelationProcessModel =
       correlation.processModels.find((entry: Runtime.Types.CorrelationProcessModel): boolean => {
-        return entry.name === this.callActivity.calledReference;
+        return entry.processModelId === this.callActivity.calledReference;
       });
 
     let callActivityResult: any;

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -96,7 +96,7 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new Error(`Cannot resume CallActivity instance ${flowNodeInstance.id}, because it was terminated!`);
+        throw new InternalServerError(`Cannot resume CallActivity instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume CallActivity instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -130,7 +130,8 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
       callActivityResult = processStartResponse.tokenPayload;
     } else {
       // Subprocess was already started. Resume it and wait for the result:
-      callActivityResult = await this._resumeProcessService.resumeProcessInstanceById(matchingSubProcess.processInstanceId);
+      callActivityResult =
+        await this._resumeProcessService.resumeProcessInstanceById(identity, matchingSubProcess.processModelId, matchingSubProcess.processInstanceId);
     }
 
     onSuspendToken.payload = callActivityResult;

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -65,31 +65,25 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
                                 identity: IIdentity,
                               ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
+        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const noMessageReceivedYet: boolean = resumeToken === undefined;
         if (noMessageReceivedYet) {
-          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -83,7 +83,7 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       default:
-        throw new InternalServerError(`Cannot resume StartEvent instance ${flowNodeInstance.id}, because it was already finished!`);
+        throw new InternalServerError(`Cannot resume CallActivity instance ${flowNodeInstance.id}, because it was already finished!`);
     }
   }
 

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -175,7 +175,7 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
    * Resumes the given FlowNodeInstance from the point where it assumed the
    * "onResumed" state.
    *
-   * Basically, the StartEvent was already finished.
+   * Basically, the handler had already finished.
    * The final result is only missing in the database.
    *
    * @async

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -61,57 +61,6 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
     return this._executeHandler(token, processTokenFacade, processModelFacade, identity);
   }
 
-  public async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade,
-                                identity: IIdentity,
-                              ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming FlowNodeInstance ${flowNodeInstance.id}.`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.suspended:
-        this.logger.verbose(`FlowNodeInstance was left suspended. Waiting for the CallActivity to be finished.`);
-        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
-
-        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade, identity);
-      case Runtime.Types.FlowNodeInstanceState.running:
-
-        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
-
-        const noMessageReceivedYet: boolean = resumeToken === undefined;
-        if (noMessageReceivedYet) {
-          this.logger.verbose(`FlowNodeInstance was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
-        }
-
-        this.logger.verbose(`The CallActivity was already finished and the handler resumed. Finishing up the handler.`);
-
-        return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`FlowNodeInstance was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-
-      default:
-        const invalidStateError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
-  }
-
   protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
                                         onSuspendToken: Runtime.Types.ProcessToken,
                                         processTokenFacade: IProcessTokenFacade,

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -73,7 +73,6 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade, identity);
@@ -88,11 +87,9 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.callActivity.id, onExitToken);
 
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -203,12 +200,33 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
                                     ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.callActivity.id, resumeToken.payload);
-
-    const nextNodeAfter: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.callActivity);
-
     await this.persistOnExit(resumeToken);
 
-    return new NextFlowNodeInfo(nextNodeAfter, resumeToken, processTokenFacade);
+    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
+  }
+
+  /**
+   * Resumes the given FlowNodeInstance from the point where it assumed the
+   * "onExit" state.
+   *
+   * Basically, the handler had already finished.
+   * We just need to return the info about the next FlowNode to run.
+   *
+   * @async
+   * @param   resumeToken        The ProcessToken stored after resuming the
+   *                             FlowNodeInstance.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade,
+                                    ): Promise<NextFlowNodeInfo> {
+
+    processTokenFacade.addResultForFlowNode(this.callActivity.id, onExitToken.payload);
+
+    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
   }
 
   private async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -75,9 +75,9 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
             return token.type === Runtime.Types.ProcessTokenType.onResume;
           });
 
-        const startEventConditionNotYetAchieved: boolean = resumeToken === undefined;
+        const callActivityNotYetExecuted: boolean = resumeToken === undefined;
 
-        if (startEventConditionNotYetAchieved) {
+        if (callActivityNotYetExecuted) {
           return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade, identity);
         }
 

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -141,17 +141,6 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
     return this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                       processTokenFacade: IProcessTokenFacade,
-                                       processModelFacade: IProcessModelFacade,
-                                      ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.callActivity.id, resumeToken.payload);
-    await this.persistOnExit(resumeToken);
-
-    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
-  }
-
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade,

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -123,10 +123,13 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
     const correlation: Runtime.Types.Correlation
       = await this._correlationService.getSubprocessesForProcessInstance(flowNodeInstance.processInstanceId);
 
-    const matchingSubProcess: Runtime.Types.CorrelationProcessModel =
-      correlation.processModels.find((entry: Runtime.Types.CorrelationProcessModel): boolean => {
-        return entry.processModelId === this.callActivity.calledReference;
-      });
+    const noSubProcessesFound: boolean = correlation === undefined;
+
+    const matchingSubProcess: Runtime.Types.CorrelationProcessModel = noSubProcessesFound
+      ? undefined
+      : correlation.processModels.find((entry: Runtime.Types.CorrelationProcessModel): boolean => {
+          return entry.processModelId === this.callActivity.calledReference;
+        });
 
     let callActivityResult: any;
 

--- a/src/runtime/engine/flow_node_handler/end_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/end_event_handler.ts
@@ -74,7 +74,7 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new Error(`Cannot resume EndEvent instance ${flowNodeInstance.id}, because it was terminated!`);
+        throw new InternalServerError(`Cannot resume EndEvent instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume EndEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/end_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/end_event_handler.ts
@@ -63,13 +63,11 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
       case Runtime.Types.FlowNodeInstanceState.running:
         const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
-        return this._executeHandler(onEnterToken, processTokenFacade);
+        return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.finished:
+      const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.endEvent.id, onExitToken);
-
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+      return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -79,7 +77,7 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
     }
   }
 
-  private async _executeHandler(token: Runtime.Types.ProcessToken, processTokenFacade: IProcessTokenFacade): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken, processTokenFacade: IProcessTokenFacade): Promise<NextFlowNodeInfo> {
 
     const flowNodeIsTerminateEndEvent: boolean = this.endEvent.terminateEventDefinition !== undefined;
     const flowNodeIsErrorEndEvent: boolean = this.endEvent.errorEventDefinition !== undefined;

--- a/src/runtime/engine/flow_node_handler/end_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/end_event_handler.ts
@@ -53,19 +53,13 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
-        const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.finished:
-      const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+      const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
       return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/end_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/end_event_handler.ts
@@ -61,7 +61,6 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
-
         const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._executeHandler(onEnterToken, processTokenFacade);

--- a/src/runtime/engine/flow_node_handler/end_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/end_event_handler.ts
@@ -44,7 +44,7 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
-    this.logger.verbose(`Executing external EndEvent instance ${this.flowNodeInstanceId}`);
+    this.logger.verbose(`Executing EndEvent instance ${this.flowNodeInstanceId}`);
     await this.persistOnEnter(token);
 
     return this._executeHandler(token, processTokenFacade);

--- a/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
@@ -43,19 +43,13 @@ export class ExclusiveGatewayHandler extends FlowNodeHandler<Model.Gateways.Excl
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
-        const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
@@ -46,7 +46,7 @@ export class ExclusiveGatewayHandler extends FlowNodeHandler<Model.Gateways.Excl
                                      processModelFacade: IProcessModelFacade,
                                     ): Promise<NextFlowNodeInfo> {
 
-    processTokenFacade.addResultForFlowNode(this.exclusiveGateway.id, onExitToken);
+    processTokenFacade.addResultForFlowNode(this.exclusiveGateway.id, onExitToken.payload);
 
     const isExclusiveJoinGateway: boolean = this.exclusiveGateway.gatewayDirection === Model.Gateways.GatewayDirection.Converging;
     if (isExclusiveJoinGateway) {
@@ -83,8 +83,7 @@ export class ExclusiveGatewayHandler extends FlowNodeHandler<Model.Gateways.Excl
       throw unsupportedError;
     }
 
-    const currentToken: any = await processTokenFacade.getOldTokenFormat();
-    processTokenFacade.addResultForFlowNode(this.exclusiveGateway.id, currentToken.current);
+    processTokenFacade.addResultForFlowNode(this.exclusiveGateway.id, token.payload);
 
     const outgoingSequenceFlows: Array<Model.Types.SequenceFlow> = processModelFacade.getOutgoingSequenceFlowsFor(this.exclusiveGateway.id);
 

--- a/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
@@ -51,7 +51,6 @@ export class ExclusiveGatewayHandler extends FlowNodeHandler<Model.Gateways.Excl
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
-
         const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);

--- a/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
@@ -78,7 +78,7 @@ export class ExclusiveGatewayHandler extends FlowNodeHandler<Model.Gateways.Excl
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new Error(`Cannot resume ExclusiveGateway instance ${flowNodeInstance.id}, because it was terminated!`);
+        throw new InternalServerError(`Cannot resume ExclusiveGateway instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume ExclusiveGateway instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
@@ -83,10 +83,10 @@ export class ExclusiveGatewayHandler extends FlowNodeHandler<Model.Gateways.Excl
 
     // Since the Gateway was finished without error, we can assume that only one outgoing SequenceFlow with a matching condition exists.
     // If this were not the case, the Gateway would not have been executed at all.
-    const matchingSequenceFlow: Model.Types.SequenceFlow =
-      this._getSequenceFlowsWithMatchingCondition(outgoingSequenceFlows, processTokenFacade)[0];
+    const matchingSequenceFlows: Array<Model.Types.SequenceFlow> =
+      await this._getSequenceFlowsWithMatchingCondition(outgoingSequenceFlows, processTokenFacade);
 
-    const nextFlowNodeAfterSplit: Model.Base.FlowNode = processModelFacade.getFlowNodeById(matchingSequenceFlow.targetRef);
+    const nextFlowNodeAfterSplit: Model.Base.FlowNode = processModelFacade.getFlowNodeById(matchingSequenceFlows[0].targetRef);
 
     return new NextFlowNodeInfo(nextFlowNodeAfterSplit, onExitToken, processTokenFacade);
   }

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -28,8 +28,7 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsApiService: IMetricsApi,
-              flowNode: TFlowNode,
-            ) {
+              flowNode: TFlowNode) {
     this._flowNodeInstanceService = flowNodeInstanceService;
     this._loggingApiService = loggingApiService;
     this._metricsApiService = metricsApiService;

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -169,6 +169,72 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                                            ): Promise<NextFlowNodeInfo>;
 
   /**
+   * Resumes the given FlowNodeInstance from the point where it assumed the
+   * "onEnter" state.
+   *
+   * Basically, the handler was not yet executed, except for the initial
+   * state change.
+   *
+   * @async
+   * @param   onEnterToken       The token the FlowNodeInstance had when it was
+   *                             started.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @param   identity           The requesting user's identity.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  protected async _continueAfterEnter(onEnterToken: Runtime.Types.ProcessToken,
+                                      processTokenFacade: IProcessTokenFacade,
+                                      processModelFacade: IProcessModelFacade,
+                                      identity?: IIdentity,
+                                    ): Promise<NextFlowNodeInfo> {
+
+    return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade, identity);
+  }
+
+  /**
+   * Resumes the given FlowNodeInstance from the point where it assumed the
+   * "onExit" state.
+   *
+   * Basically, the handler had already finished.
+   * We just need to return the info about the next FlowNode to run.
+   *
+   * @async
+   * @param   resumeToken        The ProcessToken stored after resuming the
+   *                             FlowNodeInstance.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  protected async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
+                                     processTokenFacade: IProcessTokenFacade,
+                                     processModelFacade: IProcessModelFacade,
+                                    ): Promise<NextFlowNodeInfo> {
+
+    processTokenFacade.addResultForFlowNode(this.flowNode.id, onExitToken.payload);
+
+    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+  }
+
+  /**
+   * Contains all common logic for executing and resuming FlowNodeHandlers.
+   *
+   * @async
+   * @param   token              The FlowNodeInstances current ProcessToken.
+   * @param   processTokenFacade The ProcessTokenFacade to use.
+   * @param   processModelFacade The processModelFacade to use.
+   * @param   identity           The requesting users identity.
+   * @returns                    Info about the next FlowNode to run.
+   */
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade,
+                                  identity?: IIdentity,
+                                 ): Promise<NextFlowNodeInfo> {
+    return this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+  }
+
+  /**
    * Persists the current state of the FlowNodeInstance, after it successfully started execution.
    *
    * @async

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -80,7 +80,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
     if (!nextFlowNode) {
       throw new Error(`Next flow node after node with id "${this.flowNode.id}" could not be found.`);
     }
-
     await this.afterExecute(nextFlowNode.flowNode, nextFlowNode.processTokenFacade, processModelFacade);
 
     return nextFlowNode;
@@ -107,7 +106,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
     if (!nextFlowNode) {
       throw new Error(`Next flow node after node with id "${this.flowNode.id}" could not be found.`);
     }
-
     await this.afterExecute(nextFlowNode.flowNode, nextFlowNode.processTokenFacade, processModelFacade);
 
     return nextFlowNode;
@@ -182,7 +180,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                                       processModelFacade: IProcessModelFacade,
                                       identity?: IIdentity,
                                      ): Promise<NextFlowNodeInfo> {
-
     return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade, identity);
   }
 
@@ -206,7 +203,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                                         processModelFacade: IProcessModelFacade,
                                         identity?: IIdentity,
                                        ): Promise<NextFlowNodeInfo> {
-
     processTokenFacade.addResultForFlowNode(this.flowNode.id, onSuspendToken.payload);
     await this.persistOnResume(onSuspendToken);
     await this.persistOnExit(onSuspendToken);
@@ -232,7 +228,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                                        processModelFacade: IProcessModelFacade,
                                        identity?: IIdentity,
                                       ): Promise<NextFlowNodeInfo> {
-
     processTokenFacade.addResultForFlowNode(this.flowNode.id, resumeToken.payload);
     await this.persistOnExit(resumeToken);
 
@@ -260,7 +255,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                                      processModelFacade: IProcessModelFacade,
                                      identity?: IIdentity,
                                     ): Promise<NextFlowNodeInfo> {
-
     processTokenFacade.addResultForFlowNode(this.flowNode.id, onExitToken.payload);
 
     return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
@@ -491,7 +485,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
     await processTokenFacade.evaluateMapperForFlowNode(this.flowNode);
 
     const nextSequenceFlow: Model.Types.SequenceFlow = processModelFacade.getSequenceFlowBetween(this.flowNode, nextFlowNode);
-
     if (!nextSequenceFlow) {
       return;
     }

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -176,7 +176,7 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
         return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
 
       case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`FlowNodeInstance was finished. Reconstructing branches.`);
+        this.logger.verbose(`FlowNodeInstance was already finished. Skipping ahead.`);
         const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade, identity);
@@ -192,8 +192,7 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
         throw new InternalServerError(terminatedError);
 
       default:
-        const invalidStateError: string =
-          `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because its state cannot be determined!`;
+        const invalidStateError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because its state cannot be determined!`;
         this.logger.error(invalidStateError);
         throw new InternalServerError(invalidStateError);
     }

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -85,7 +85,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
     if (!nextFlowNode) {
       throw new Error(`Next flow node after node with id "${this.flowNode.id}" could not be found.`);
     }
-    await this.afterExecute(nextFlowNode.flowNode, nextFlowNode.processTokenFacade, processModelFacade);
 
     return nextFlowNode;
   }
@@ -111,7 +110,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
     if (!nextFlowNode) {
       throw new Error(`Next flow node after node with id "${this.flowNode.id}" could not be found.`);
     }
-    await this.afterExecute(nextFlowNode.flowNode, nextFlowNode.processTokenFacade, processModelFacade);
 
     return nextFlowNode;
   }
@@ -507,30 +505,5 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
     const nextFlowNode: Model.Base.FlowNode = await processModelFacade.getNextFlowNodeFor(this.flowNode);
 
     return new NextFlowNodeInfo(nextFlowNode, token, processTokenFacade);
-  }
-
-  /**
-   * Performs post-execution operations for the FlowNode that this Handler is
-   * responsible for.
-   *
-   * @async
-   * @param nextFlowNode       The FlowNode that follows after this one.
-   * @param processTokenFacade The ProcessTokenFacade of the curently running
-   *                           process.
-   * @param processModelFacade The ProcessModelFacade of the curently running
-   *                           process.
-   */
-  private async afterExecute(nextFlowNode: Model.Base.FlowNode,
-                             processTokenFacade: IProcessTokenFacade,
-                             processModelFacade: IProcessModelFacade): Promise<void> {
-
-    await processTokenFacade.evaluateMapperForFlowNode(this.flowNode);
-
-    const nextSequenceFlow: Model.Types.SequenceFlow = processModelFacade.getSequenceFlowBetween(this.flowNode, nextFlowNode);
-    if (!nextSequenceFlow) {
-      return;
-    }
-
-    await processTokenFacade.evaluateMapperForSequenceFlow(nextSequenceFlow);
   }
 }

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -94,18 +94,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
     return nextFlowNode;
   }
 
-  /**
-   * This is the method where the derived handlers must implement their logic
-   * for resuming a previously interrupted instance.
-   *
-   * @async
-   * @param flowNodeInstance   The current ProcessToken.
-   * @param processTokenFacade The ProcessTokenFacade of the curently
-   *                           running process.
-   * @param processModelFacade The ProcessModelFacade of the curently
-   *                           running process.
-   * @param identity           The requesting users identity.
-   */
   public async resume(flowNodeInstance: Runtime.Types.FlowNodeInstance,
                       processTokenFacade: IProcessTokenFacade,
                       processModelFacade: IProcessModelFacade,

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -482,8 +482,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                              processTokenFacade: IProcessTokenFacade,
                              processModelFacade: IProcessModelFacade): Promise<void> {
 
-    // There are two kinds of Mappers to evaluate: FlowNode- and SequenceFlow-Mappers.
-    // They are evaluated in between handling of FlowNodes.
     await processTokenFacade.evaluateMapperForFlowNode(this.flowNode);
 
     const nextSequenceFlow: Model.Types.SequenceFlow = processModelFacade.getSequenceFlowBetween(this.flowNode, nextFlowNode);

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -1,5 +1,7 @@
-import {IIdentity} from '@essential-projects/iam_contracts';
+import * as moment from 'moment';
+import * as uuid from 'uuid';
 
+import {IIdentity} from '@essential-projects/iam_contracts';
 import {ILoggingApi, LogLevel} from '@process-engine/logging_api_contracts';
 import {IMetricsApi} from '@process-engine/metrics_api_contracts';
 import {
@@ -11,9 +13,6 @@ import {
   NextFlowNodeInfo,
   Runtime,
 } from '@process-engine/process_engine_contracts';
-
-import * as moment from 'moment';
-import * as uuid from 'uuid';
 
 export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> implements IFlowNodeHandler<TFlowNode> {
 
@@ -68,19 +67,13 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                       ): Promise<NextFlowNodeInfo> {
 
     this._previousFlowNodeInstanceId = previousFlowNodeInstanceId;
-
     token.flowNodeInstanceId = this.flowNodeInstanceId;
-
     let nextFlowNode: NextFlowNodeInfo;
 
     try {
       nextFlowNode = await this.executeInternally(token, processTokenFacade, processModelFacade, identity);
-
     } catch (error) {
-      // TODO: (SM) this is only to support the old implementation
-      //            I would like to set no token result or further specify it to be an error to avoid confusion
       await processTokenFacade.addResultForFlowNode(this.flowNode.id, error);
-
       throw error;
     }
 
@@ -97,7 +90,7 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                       processTokenFacade: IProcessTokenFacade,
                       processModelFacade: IProcessModelFacade,
                       identity: IIdentity,
-                    ): Promise<NextFlowNodeInfo> {
+                     ): Promise<NextFlowNodeInfo> {
 
     this._previousFlowNodeInstanceId = flowNodeInstance.previousFlowNodeInstanceId;
     this._flowNodeInstanceId = flowNodeInstance.id;
@@ -106,10 +99,8 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
 
     try {
       nextFlowNode = await this.resumeInternally(flowNodeInstance, processTokenFacade, processModelFacade, identity);
-
     } catch (error) {
       await processTokenFacade.addResultForFlowNode(this.flowNode.id, error);
-
       throw error;
     }
 
@@ -155,12 +146,14 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
    * for resuming a previously interrupted instance.
    *
    * @async
-   * @param flowNodeInstance   The current ProcessToken.
-   * @param processTokenFacade The ProcessTokenFacade of the curently
-   *                           running process.
-   * @param processModelFacade The ProcessModelFacade of the curently
-   *                           running process.
-   * @param identity           The requesting users identity.
+   * @param   flowNodeInstance   The current ProcessToken.
+   * @param   processTokenFacade The ProcessTokenFacade of the curently
+   *                             running process.
+   * @param   processModelFacade The ProcessModelFacade of the curently
+   *                             running process.
+   * @param   identity           The identity of the user that originally
+   *                             started the ProcessInstance.
+   * @returns                    The Info for the next FlowNode to run.
    */
   protected async abstract resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
                                             processTokenFacade: IProcessTokenFacade,
@@ -180,7 +173,8 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
    *                             started.
    * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
    * @param   processModelFacade The processModelFacade to use for resuming.
-   * @param   identity           The requesting user's identity.
+   * @param   identity           The identity of the user that originally
+   *                             started the ProcessInstance.
    * @returns                    The Info for the next FlowNode to run.
    */
   protected async _continueAfterEnter(onEnterToken: Runtime.Types.ProcessToken,
@@ -190,6 +184,56 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                                     ): Promise<NextFlowNodeInfo> {
 
     return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade, identity);
+  }
+
+  /**
+   * Resumes the given FlowNodeInstance from the point where it assumed the
+   * "onSuspended" state.
+   *
+   * @async
+   * @param   flowNodeInstance   The FlowNodeInstance to resume.
+   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
+   *                             suspended.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @param   identity           The identity of the user that originally
+   *                             started the ProcessInstance.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                        identity?: IIdentity,
+                                       ): Promise<NextFlowNodeInfo> {
+
+    processTokenFacade.addResultForFlowNode(this.flowNode.id, onSuspendToken.payload);
+
+    return this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);
+  }
+
+  /**
+   * Resumes the given FlowNodeInstance from the point where it resumed activity,
+   * after having been suspended.
+   *
+   * @async
+   * @param   resumeToken        The ProcessToken stored after resuming the
+   *                             FlowNodeInstance.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @param   identity           The identity of the user that originally
+   *                             started the ProcessInstance.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                       identity?: IIdentity,
+                                      ): Promise<NextFlowNodeInfo> {
+
+    processTokenFacade.addResultForFlowNode(this.flowNode.id, resumeToken.payload);
+
+    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
   }
 
   /**
@@ -409,10 +453,8 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
    *
    * @async
    * @param token              The current Processtoken.
-   * @param processTokenFacade The ProcessTokenFacade to use with the next
-   *                           FlowNode.
-   * @param processModelFacade The ProcessModelFacade to use with the next
-   *                           FlowNode.
+   * @param processTokenFacade The ProcessTokenFacade to use with the next FlowNode.
+   * @param processModelFacade The ProcessModelFacade to use with the next FlowNode.
    * @returns                  The NextFlowNodeInfo object for the next FlowNode
    *                           to run.
    */
@@ -428,9 +470,6 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
   /**
    * Performs post-execution operations for the FlowNode that this Handler is
    * responsible for.
-   *
-   * This includes evaluating mappers on the succeeding FlowNodes or
-   * SequenceFlows.
    *
    * @async
    * @param nextFlowNode       The FlowNode that follows after this one.

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -181,7 +181,7 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                                       processTokenFacade: IProcessTokenFacade,
                                       processModelFacade: IProcessModelFacade,
                                       identity?: IIdentity,
-                                    ): Promise<NextFlowNodeInfo> {
+                                     ): Promise<NextFlowNodeInfo> {
 
     return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade, identity);
   }
@@ -251,11 +251,14 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
    *                             FlowNodeInstance.
    * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
    * @param   processModelFacade The processModelFacade to use for resuming.
+   * @param   identity           The identity of the user that originally
+   *                             started the ProcessInstance.
    * @returns                    The Info for the next FlowNode to run.
    */
   protected async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
                                      processTokenFacade: IProcessTokenFacade,
                                      processModelFacade: IProcessModelFacade,
+                                     identity?: IIdentity,
                                     ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.flowNode.id, onExitToken.payload);

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -208,6 +208,8 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                                        ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.flowNode.id, onSuspendToken.payload);
+    await this.persistOnResume(onSuspendToken);
+    await this.persistOnExit(onSuspendToken);
 
     return this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);
   }
@@ -232,6 +234,7 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                                       ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.flowNode.id, resumeToken.payload);
+    await this.persistOnExit(resumeToken);
 
     return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
   }

--- a/src/runtime/engine/flow_node_handler/intermediate_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_catch_event_handler.ts
@@ -110,7 +110,7 @@ export class IntermediateCatchEventHandler extends FlowNodeHandler<Model.Events.
                                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
     const eventHandler: FlowNodeHandler<Model.Events.IntermediateCatchEvent> =
-      await this.container.resolveAsync<FlowNodeHandler<Model.Events.IntermediateCatchEvent>>(eventHandlerName, [this.flowNode]);
+      await this._container.resolveAsync<FlowNodeHandler<Model.Events.IntermediateCatchEvent>>(eventHandlerName, [this.flowNode]);
 
     return eventHandler.resume(flowNodeInstance, processTokenFacade, processModelFacade, identity);
   }

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -59,7 +59,6 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
@@ -74,11 +73,9 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.messageCatchEvent.id, onExitToken);
 
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -155,12 +152,33 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
                                     ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.messageCatchEvent.id, resumeToken.payload);
-
-    const nextNodeAfterUserTask: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.messageCatchEvent);
-
     await this.persistOnExit(resumeToken);
 
-    return new NextFlowNodeInfo(nextNodeAfterUserTask, resumeToken, processTokenFacade);
+    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
+  }
+
+  /**
+   * Resumes the given FlowNodeInstance from the point where it assumed the
+   * "onExit" state.
+   *
+   * Basically, the handler had already finished.
+   * We just need to return the info about the next FlowNode to run.
+   *
+   * @async
+   * @param   resumeToken        The ProcessToken stored after resuming the
+   *                             FlowNodeInstance.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade,
+                                    ): Promise<NextFlowNodeInfo> {
+
+    processTokenFacade.addResultForFlowNode(this.messageCatchEvent.id, onExitToken.payload);
+
+    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
   }
 
   private async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -23,8 +23,6 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
 
   private _eventAggregator: IEventAggregator;
 
-  private logger: Logger;
-
   constructor(eventAggregator: IEventAggregator,
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingService: ILoggingApi,

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -68,7 +68,9 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
 
         const messageNotYetReceived: boolean = resumeToken === undefined;
         if (messageNotYetReceived) {
-          return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
+          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+
+          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
@@ -85,26 +87,10 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
     }
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onEnter" state.
-   *
-   * Basically, the handler was not yet executed, except for the initial
-   * state change.
-   *
-   * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterEnter(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                    processTokenFacade: IProcessTokenFacade,
-                                    processModelFacade: IProcessModelFacade,
-                                   ): Promise<NextFlowNodeInfo> {
-
-    // When the FNI was interrupted directly after the onEnter state change, only one token will be present.
-    const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
+  protected async _continueAfterEnter(onEnterToken: Runtime.Types.ProcessToken,
+                                      processTokenFacade: IProcessTokenFacade,
+                                      processModelFacade: IProcessModelFacade,
+                                     ): Promise<NextFlowNodeInfo> {
 
     await this.persistOnSuspend(onEnterToken);
 
@@ -157,33 +143,9 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
     return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onExit" state.
-   *
-   * Basically, the handler had already finished.
-   * We just need to return the info about the next FlowNode to run.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.messageCatchEvent.id, onExitToken.payload);
-
-    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
-  }
-
-  private async _executeHandler(token: Runtime.Types.ProcessToken,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
     const receivedMessage: MessageEventReachedMessage = await this._waitForMessage();
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -106,17 +106,6 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                       processTokenFacade: IProcessTokenFacade,
-                                       processModelFacade: IProcessModelFacade,
-                                      ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.messageCatchEvent.id, resumeToken.payload);
-    await this.persistOnExit(resumeToken);
-
-    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
-  }
-
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -45,11 +45,11 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
     return await this._executeHandler(token, processTokenFacade, processModelFacade);
   }
 
-  public async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade,
-                                identity: IIdentity,
-                              ): Promise<NextFlowNodeInfo> {
+  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade,
+                                   identity: IIdentity,
+                                 ): Promise<NextFlowNodeInfo> {
 
     function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
       return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
@@ -67,8 +67,8 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
 
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
-        const noMessageReceivedYet: boolean = resumeToken === undefined;
-        if (noMessageReceivedYet) {
+        const messageNotYetReceived: boolean = resumeToken === undefined;
+        if (messageNotYetReceived) {
           return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
         }
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -45,30 +45,46 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
     return await this._executeHandler(token, processTokenFacade, processModelFacade);
   }
 
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                 ): Promise<NextFlowNodeInfo> {
+  public async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                processTokenFacade: IProcessTokenFacade,
+                                processModelFacade: IProcessModelFacade,
+                                identity: IIdentity,
+                              ): Promise<NextFlowNodeInfo> {
+
+    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
+      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
+        return token.type === tokenType;
+      });
+    }
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        return this._continueAfterSuspend(flowNodeInstance, processTokenFacade, processModelFacade);
+
+        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+
+        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken =
-          flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-            return token.type === Runtime.Types.ProcessTokenType.onResume;
-          });
+        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
-        const messageNotYetReceived: boolean = resumeToken === undefined;
-        if (messageNotYetReceived) {
+        const noMessageReceivedYet: boolean = resumeToken === undefined;
+        if (noMessageReceivedYet) {
           return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.finished:
+
+        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        processTokenFacade.addResultForFlowNode(this.messageCatchEvent.id, onExitToken);
+
+        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+        throw flowNodeInstance.error;
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+        throw new InternalServerError(`Cannot resume MessageCatchEvent instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
-        throw new InternalServerError(`Cannot resume MessageCatchEvent instance ${flowNodeInstance.id}, because it was already finished!`);
+        throw new InternalServerError(`Cannot resume MessageCatchEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }
   }
 
@@ -106,22 +122,17 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
    * again and wait for the message.
    *
    * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
+   * @param   onSuspendToken     The FlowNodeInstance to resume.
    * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
    * @param   processModelFacade The processModelFacade to use for resuming.
    * @returns                    The Info for the next FlowNode to run.
    */
-  private async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
                                       processTokenFacade: IProcessTokenFacade,
                                       processModelFacade: IProcessModelFacade,
                                      ): Promise<NextFlowNodeInfo> {
 
-    const suspendToken: Runtime.Types.ProcessToken =
-      flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === Runtime.Types.ProcessTokenType.onSuspend;
-      });
-
-    return this._executeHandler(suspendToken, processTokenFacade, processModelFacade);
+    return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
   /**

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -128,7 +128,7 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
    * Resumes the given FlowNodeInstance from the point where it assumed the
    * "onResumed" state.
    *
-   * Basically, the message was alrady received, but the final state change
+   * Basically, the message was already received, but the final state change
    * did not happen.
    *
    * @async

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -59,26 +59,20 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
 
     this.logger.verbose(`Resuming MessageCatchEvent instance ${flowNodeInstance.id}`);
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
         this.logger.verbose(`MessageCatchEvent ${flowNodeInstance.id} was left suspended. Waiting for the Message to be received.`);
-        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
 
       case Runtime.Types.FlowNodeInstanceState.running:
-        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
+        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const messageNotYetReceived: boolean = resumeToken === undefined;
         if (messageNotYetReceived) {
           this.logger.verbose(`MessageCatchEvent ${flowNodeInstance.id} was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
@@ -89,7 +83,7 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
 
       case Runtime.Types.FlowNodeInstanceState.finished:
         this.logger.verbose(`MessageCatchEvent ${flowNodeInstance.id} was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -49,59 +49,6 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
     return await this._executeHandler(token, processTokenFacade, processModelFacade);
   }
 
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                 ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming MessageCatchEvent instance ${flowNodeInstance.id}`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.suspended:
-        this.logger.verbose(`MessageCatchEvent ${flowNodeInstance.id} was left suspended. Waiting for the Message to be received.`);
-        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
-
-        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
-
-      case Runtime.Types.FlowNodeInstanceState.running:
-        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
-
-        const messageNotYetReceived: boolean = resumeToken === undefined;
-        if (messageNotYetReceived) {
-          this.logger.verbose(`MessageCatchEvent ${flowNodeInstance.id} was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
-        }
-
-        this.logger.verbose(`MessageCatchEvent ${flowNodeInstance.id} already received its message. Finishing up the handler.`);
-
-        return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`MessageCatchEvent ${flowNodeInstance.id} was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume MessageCatchEvent instance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume MessageCatchEvent instance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-
-      default:
-        const invalidStateError: string = `Cannot resume MessageCatchEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
-  }
-
   protected async _continueAfterEnter(onEnterToken: Runtime.Types.ProcessToken,
                                       processTokenFacade: IProcessTokenFacade,
                                       processModelFacade: IProcessModelFacade,

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -1,6 +1,5 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -61,7 +61,7 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
       case Runtime.Types.FlowNodeInstanceState.suspended:
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
-        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
+        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
@@ -97,45 +97,19 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandler<Model.
     return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onSuspended" state.
-   *
-   * When resuming at this stage, we need to subscribe to the EventAggregator
-   * again and wait for the message.
-   *
-   * @async
-   * @param   onSuspendToken     The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                     ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onResumed" state.
-   *
-   * Basically, the message was already received, but the final state change
-   * did not happen.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                     processTokenFacade: IProcessTokenFacade,
-                                     processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.messageCatchEvent.id, resumeToken.payload);
     await this.persistOnExit(resumeToken);

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_throw_event_handler.ts
@@ -23,8 +23,6 @@ export class IntermediateMessageThrowEventHandler extends FlowNodeHandler<Model.
 
   private _eventAggregator: IEventAggregator;
 
-  private logger: Logger;
-
   constructor(eventAggregator: IEventAggregator,
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingService: ILoggingApi,
@@ -48,40 +46,6 @@ export class IntermediateMessageThrowEventHandler extends FlowNodeHandler<Model.
     await this.persistOnEnter(token);
 
     return this._executeHandler(token, processTokenFacade, processModelFacade);
-  }
-
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                  ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming MessageThrowEvent instance ${flowNodeInstance.id}`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.running:
-        this.logger.verbose(`MessageThrowEvent ${flowNodeInstance.id} was interrupted before it could finish. Restarting the handler.`);
-        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-        return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`MessageThrowEvent ${flowNodeInstance.id} was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume MessageThrowEvent instance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume MessageThrowEvent instance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-      default:
-        const invalidStateError: string = `Cannot resume MessageThrowEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
   }
 
   protected async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_throw_event_handler.ts
@@ -58,21 +58,15 @@ export class IntermediateMessageThrowEventHandler extends FlowNodeHandler<Model.
 
     this.logger.verbose(`Resuming MessageThrowEvent instance ${flowNodeInstance.id}`);
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
         this.logger.verbose(`MessageThrowEvent ${flowNodeInstance.id} was interrupted before it could finish. Restarting the handler.`);
-        const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
         this.logger.verbose(`MessageThrowEvent ${flowNodeInstance.id} was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_throw_event_handler.ts
@@ -96,6 +96,5 @@ export class IntermediateMessageThrowEventHandler extends FlowNodeHandler<Model.
     await this.persistOnExit(token);
 
     return new NextFlowNodeInfo(nextFlowNode, token, processTokenFacade);
-
   }
 }

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_throw_event_handler.ts
@@ -57,16 +57,13 @@ export class IntermediateMessageThrowEventHandler extends FlowNodeHandler<Model.
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
-
         const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
-        return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);
+        return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.messageThrowEvent.id, onExitToken);
 
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -76,9 +73,9 @@ export class IntermediateMessageThrowEventHandler extends FlowNodeHandler<Model.
     }
   }
 
-  private async _executeHandler(token: Runtime.Types.ProcessToken,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
     const messageName: string = this.messageThrowEvent.messageEventDefinition.name;
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_throw_event_handler.ts
@@ -1,6 +1,5 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -106,17 +106,6 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                       processTokenFacade: IProcessTokenFacade,
-                                       processModelFacade: IProcessModelFacade,
-                                      ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.signalCatchEvent.id, resumeToken.payload);
-    await this.persistOnExit(resumeToken);
-
-    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
-  }
-
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -61,7 +61,7 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
       case Runtime.Types.FlowNodeInstanceState.suspended:
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
-        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
+        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
@@ -97,45 +97,19 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
     return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onSuspended" state.
-   *
-   * When resuming at this stage, we need to subscribe to the EventAggregator
-   * again and wait for the signal.
-   *
-   * @async
-   * @param   onSuspendToken     The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                     ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onResumed" state.
-   *
-   * Basically, the signal was already received, but the final state change
-   * did not happen.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                     processTokenFacade: IProcessTokenFacade,
-                                     processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.signalCatchEvent.id, resumeToken.payload);
     await this.persistOnExit(resumeToken);

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -128,7 +128,7 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
    * Resumes the given FlowNodeInstance from the point where it assumed the
    * "onResumed" state.
    *
-   * Basically, the signal was alrady received, but the final state change
+   * Basically, the signal was already received, but the final state change
    * did not happen.
    *
    * @async

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -49,59 +49,6 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
     return await this._executeHandler(token, processTokenFacade, processModelFacade);
   }
 
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                 ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming SignalCatchEvent instance ${flowNodeInstance.id}`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.suspended:
-        this.logger.verbose(`SignalCatchEvent was left suspended. Waiting for the Message to be received.`);
-        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
-
-        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
-
-      case Runtime.Types.FlowNodeInstanceState.running:
-        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
-
-        const messageNotYetReceived: boolean = resumeToken === undefined;
-        if (messageNotYetReceived) {
-          this.logger.verbose(`SignalCatchEvent was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
-        }
-
-        this.logger.verbose(`The message was already received and the handler resumed. Finishing up the handler.`);
-
-        return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`SignalCatchEvent was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume SignalCatchEvent instance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume SignalCatchEvent instance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-
-      default:
-        const invalidStateError: string = `Cannot resume SignalCatchEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
-  }
-
   protected async _continueAfterEnter(onEnterToken: Runtime.Types.ProcessToken,
                                       processTokenFacade: IProcessTokenFacade,
                                       processModelFacade: IProcessModelFacade,

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -23,8 +23,6 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
 
   private _eventAggregator: IEventAggregator;
 
-  private logger: Logger;
-
   constructor(eventAggregator: IEventAggregator,
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingService: ILoggingApi,

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -1,3 +1,5 @@
+import {Logger} from 'loggerhythm';
+
 import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
@@ -21,6 +23,8 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
 
   private _eventAggregator: IEventAggregator;
 
+  private logger: Logger;
+
   constructor(eventAggregator: IEventAggregator,
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingService: ILoggingApi,
@@ -28,6 +32,7 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
               signalCatchEventModel: Model.Events.IntermediateCatchEvent) {
     super(flowNodeInstanceService, loggingService, metricsService, signalCatchEventModel);
     this._eventAggregator = eventAggregator;
+    this.logger = Logger.createLogger(`processengine:signal_catch_event_handler:${signalCatchEventModel.id}`);
   }
 
   private get signalCatchEvent(): Model.Events.IntermediateCatchEvent {
@@ -39,6 +44,7 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
+    this.logger.verbose(`Executing SignalCatchEvent instance ${this.flowNodeInstanceId}.`);
     await this.persistOnEnter(token);
     await this.persistOnSuspend(token);
 
@@ -51,6 +57,8 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
                                    identity: IIdentity,
                                  ): Promise<NextFlowNodeInfo> {
 
+    this.logger.verbose(`Resuming SignalCatchEvent instance ${flowNodeInstance.id}`);
+
     function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
       return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
         return token.type === tokenType;
@@ -59,31 +67,46 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
+        this.logger.verbose(`SignalCatchEvent was left suspended. Waiting for the Message to be received.`);
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.running:
 
+      case Runtime.Types.FlowNodeInstanceState.running:
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
-        const signalNotYetReceived: boolean = resumeToken === undefined;
-        if (signalNotYetReceived) {
+        const messageNotYetReceived: boolean = resumeToken === undefined;
+        if (messageNotYetReceived) {
+          this.logger.verbose(`SignalCatchEvent was interrupted at the beginning. Resuming from the start.`);
           const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
+        this.logger.verbose(`The message was already received and the handler resumed. Finishing up the handler.`);
+
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
+
       case Runtime.Types.FlowNodeInstanceState.finished:
+        this.logger.verbose(`SignalCatchEvent was already finished. Skipping ahead.`);
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
+
       case Runtime.Types.FlowNodeInstanceState.error:
+        this.logger.error(`Cannot resume SignalCatchEvent instance ${flowNodeInstance.id}, because it previously exited with an error!`,
+                     flowNodeInstance.error);
         throw flowNodeInstance.error;
+
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new InternalServerError(`Cannot resume SignalCatchEvent instance ${flowNodeInstance.id}, because it was terminated!`);
+        const terminatedError: string = `Cannot resume SignalCatchEvent instance ${flowNodeInstance.id}, because it was terminated!`;
+        this.logger.error(terminatedError);
+        throw new InternalServerError(terminatedError);
+
       default:
-        throw new InternalServerError(`Cannot resume SignalCatchEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`);
+        const invalidStateError: string = `Cannot resume SignalCatchEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`;
+        this.logger.error(invalidStateError);
+        throw new InternalServerError(invalidStateError);
     }
   }
 
@@ -135,9 +158,15 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
         if (subscription) {
           subscription.dispose();
         }
+        this.logger.verbose(
+          `SignalCatchEvent instance ${this.flowNodeInstanceId} received signal ${signalEventName}:`,
+          signal,
+          'Resuming execution.',
+        );
 
         return resolve(signal);
       });
+      this.logger.verbose(`SignalCatchEvent instance ${this.flowNodeInstanceId} waiting for signal ${signalEventName}.`);
     });
   }
 }

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -59,26 +59,20 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
 
     this.logger.verbose(`Resuming SignalCatchEvent instance ${flowNodeInstance.id}`);
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
         this.logger.verbose(`SignalCatchEvent was left suspended. Waiting for the Message to be received.`);
-        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
 
       case Runtime.Types.FlowNodeInstanceState.running:
-        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
+        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const messageNotYetReceived: boolean = resumeToken === undefined;
         if (messageNotYetReceived) {
           this.logger.verbose(`SignalCatchEvent was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
@@ -89,7 +83,7 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
 
       case Runtime.Types.FlowNodeInstanceState.finished:
         this.logger.verbose(`SignalCatchEvent was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -68,7 +68,9 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
 
         const signalNotYetReceived: boolean = resumeToken === undefined;
         if (signalNotYetReceived) {
-          return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
+          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+
+          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
@@ -85,26 +87,10 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
     }
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onEnter" state.
-   *
-   * Basically, the handler was not yet executed, except for the initial
-   * state change.
-   *
-   * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterEnter(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                    processTokenFacade: IProcessTokenFacade,
-                                    processModelFacade: IProcessModelFacade,
-                                   ): Promise<NextFlowNodeInfo> {
-
-    // When the FNI was interrupted directly after the onEnter state change, only one token will be present.
-    const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
+  protected async _continueAfterEnter(onEnterToken: Runtime.Types.ProcessToken,
+                                      processTokenFacade: IProcessTokenFacade,
+                                      processModelFacade: IProcessModelFacade,
+                                     ): Promise<NextFlowNodeInfo> {
 
     await this.persistOnSuspend(onEnterToken);
 
@@ -157,33 +143,9 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandler<Model.E
     return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onExit" state.
-   *
-   * Basically, the handler had already finished.
-   * We just need to return the info about the next FlowNode to run.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.signalCatchEvent.id, onExitToken.payload);
-
-    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
-  }
-
-  private async _executeHandler(token: Runtime.Types.ProcessToken,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
     const receivedSignal: SignalEventReachedMessage = await this._waitForSignal();
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -1,6 +1,5 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_throw_event_handler.ts
@@ -57,21 +57,15 @@ export class IntermediateSignalThrowEventHandler extends FlowNodeHandler<Model.E
 
     this.logger.verbose(`Resuming SignalThrowEvent instance ${flowNodeInstance.id}`);
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
         this.logger.verbose(`SignalThrowEvent ${flowNodeInstance.id} was interrupted before it could finish. Restarting the handler.`);
-        const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
         this.logger.verbose(`SignalThrowEvent ${flowNodeInstance.id} was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_throw_event_handler.ts
@@ -22,7 +22,6 @@ import {FlowNodeHandler} from '../index';
 export class IntermediateSignalThrowEventHandler extends FlowNodeHandler<Model.Events.IntermediateThrowEvent> {
 
   private _eventAggregator: IEventAggregator;
-  private logger: Logger;
 
   constructor(eventAggregator: IEventAggregator,
               flowNodeInstanceService: IFlowNodeInstanceService,
@@ -47,40 +46,6 @@ export class IntermediateSignalThrowEventHandler extends FlowNodeHandler<Model.E
     await this.persistOnEnter(token);
 
     return this._executeHandler(token, processTokenFacade, processModelFacade);
-  }
-
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                  ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming SignalThrowEvent instance ${flowNodeInstance.id}`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.running:
-        this.logger.verbose(`SignalThrowEvent ${flowNodeInstance.id} was interrupted before it could finish. Restarting the handler.`);
-        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-        return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`SignalThrowEvent ${flowNodeInstance.id} was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume SignalThrowEvent instance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume SignalThrowEvent instance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-      default:
-        const invalidStateError: string = `Cannot resume SignalThrowEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
   }
 
   protected async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_throw_event_handler.ts
@@ -1,3 +1,4 @@
+import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
@@ -49,11 +50,31 @@ export class IntermediateSignalThrowEventHandler extends FlowNodeHandler<Model.E
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    // IntermediateThrowEvents only produce two tokens in their lifetime.
-    // Therefore, it is safe to assume that only one token exists at this point.
-    const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
+    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
+      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
+        return token.type === tokenType;
+      });
+    }
 
-    return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);
+    switch (flowNodeInstance.state) {
+      case Runtime.Types.FlowNodeInstanceState.running:
+
+        const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+
+        return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.finished:
+
+        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        processTokenFacade.addResultForFlowNode(this.signalThrowEvent.id, onExitToken);
+
+        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+        throw flowNodeInstance.error;
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+        throw new InternalServerError(`Cannot resume SignalThrowEvent instance ${flowNodeInstance.id}, because it was terminated!`);
+      default:
+        throw new InternalServerError(`Cannot resume SignalThrowEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`);
+    }
   }
 
   private async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_throw_event_handler.ts
@@ -1,6 +1,5 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_throw_event_handler.ts
@@ -58,16 +58,13 @@ export class IntermediateSignalThrowEventHandler extends FlowNodeHandler<Model.E
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
-
         const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
-        return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);
+        return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.signalThrowEvent.id, onExitToken);
 
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -77,9 +74,9 @@ export class IntermediateSignalThrowEventHandler extends FlowNodeHandler<Model.E
     }
   }
 
-  private async _executeHandler(token: Runtime.Types.ProcessToken,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
     const signalName: string = this.signalThrowEvent.signalEventDefinition.name;
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -64,7 +64,7 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
       case Runtime.Types.FlowNodeInstanceState.suspended:
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
-        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
+        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
@@ -100,44 +100,19 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
     return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onSuspended" state.
-   *
-   * When resuming at this stage, we need to restart the timer.
-   *
-   * @async
-   * @param   onSuspendToken     The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                     ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onResumed" state.
-   *
-   * Basically, the timer had already elapsed, but the final state change
-   * did not happen.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                     processTokenFacade: IProcessTokenFacade,
-                                     processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, resumeToken.payload);
     await this.persistOnExit(resumeToken);

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -62,7 +62,6 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
@@ -77,11 +76,9 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, onExitToken);
 
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -157,12 +154,33 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
                                     ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, resumeToken.payload);
-
-    const nextNodeAfterUserTask: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.timerCatchEvent);
-
     await this.persistOnExit(resumeToken);
 
-    return new NextFlowNodeInfo(nextNodeAfterUserTask, resumeToken, processTokenFacade);
+    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
+  }
+
+  /**
+   * Resumes the given FlowNodeInstance from the point where it assumed the
+   * "onExit" state.
+   *
+   * Basically, the handler had already finished.
+   * We just need to return the info about the next FlowNode to run.
+   *
+   * @async
+   * @param   resumeToken        The ProcessToken stored after resuming the
+   *                             FlowNodeInstance.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade,
+                                    ): Promise<NextFlowNodeInfo> {
+
+    processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, onExitToken.payload);
+
+    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
   }
 
   private async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -62,26 +62,20 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
 
     this.logger.verbose(`Resuming TimerCatchEvent instance ${flowNodeInstance.id}`);
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
         this.logger.verbose(`TimerCatchEvent ${flowNodeInstance.id} was left suspended. Restarting the timer.`);
-        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
 
       case Runtime.Types.FlowNodeInstanceState.running:
-        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
+        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const messageNotYetReceived: boolean = resumeToken === undefined;
         if (messageNotYetReceived) {
           this.logger.verbose(`TimerCatchEvent ${flowNodeInstance.id} was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
@@ -92,7 +86,7 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
 
       case Runtime.Types.FlowNodeInstanceState.finished:
         this.logger.verbose(`TimerCatchEvent ${flowNodeInstance.id} was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -130,7 +130,7 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
    * Resumes the given FlowNodeInstance from the point where it assumed the
    * "onResumed" state.
    *
-   * Basically, the timer had alrady elapsed, but the final state change
+   * Basically, the timer had already elapsed, but the final state change
    * did not happen.
    *
    * @async

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -26,8 +26,6 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
 
   private _timerFacade: ITimerFacade;
 
-  private logger: Logger;
-
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingService: ILoggingApi,
               metricsService: IMetricsApi,

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -71,7 +71,9 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
 
         const signalNotYetReceived: boolean = resumeToken === undefined;
         if (signalNotYetReceived) {
-          return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
+          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+
+          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
@@ -88,26 +90,10 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
     }
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onEnter" state.
-   *
-   * Basically, the handler was not yet executed, except for the initial
-   * state change.
-   *
-   * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterEnter(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                    processTokenFacade: IProcessTokenFacade,
-                                    processModelFacade: IProcessModelFacade,
-                                   ): Promise<NextFlowNodeInfo> {
-
-    // When the FNI was interrupted directly after the onEnter state change, only one token will be present.
-    const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
+  protected async _continueAfterEnter(onEnterToken: Runtime.Types.ProcessToken,
+                                      processTokenFacade: IProcessTokenFacade,
+                                      processModelFacade: IProcessModelFacade,
+                                     ): Promise<NextFlowNodeInfo> {
 
     await this.persistOnSuspend(onEnterToken);
 
@@ -159,33 +145,9 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
     return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onExit" state.
-   *
-   * Basically, the handler had already finished.
-   * We just need to return the info about the next FlowNode to run.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, onExitToken.payload);
-
-    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
-  }
-
-  private async _executeHandler(token: Runtime.Types.ProcessToken,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
     return new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -142,8 +142,7 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
 
         await this.persistOnResume(token);
 
-        const oldTokenFormat: any = await processTokenFacade.getOldTokenFormat();
-        await processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, oldTokenFormat.current);
+        await processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, token.payload);
 
         if (timerSubscription && timerType !== TimerDefinitionType.cycle) {
           timerSubscription.dispose();

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -109,17 +109,6 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                       processTokenFacade: IProcessTokenFacade,
-                                       processModelFacade: IProcessModelFacade,
-                                      ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, resumeToken.payload);
-    await this.persistOnExit(resumeToken);
-
-    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
-  }
-
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -70,7 +70,7 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        this.logger.verbose(`TimerCatchEvent ${flowNodeInstance.id} was left suspended. Waiting for the Message to be received.`);
+        this.logger.verbose(`TimerCatchEvent ${flowNodeInstance.id} was left suspended. Restarting the timer.`);
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -1,6 +1,5 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
 import {ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
@@ -17,10 +16,7 @@ import {
   TimerDefinitionType,
 } from '@process-engine/process_engine_contracts';
 
-import {Logger} from 'loggerhythm';
 import {FlowNodeHandler} from '../index';
-
-const logger: Logger = Logger.createLogger('processengine:runtime:intermediate_timer_catch_event');
 
 export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Events.IntermediateCatchEvent> {
 
@@ -121,7 +117,7 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
       return evaluateFunction.call(tokenData, tokenData);
 
     } catch (err) {
-      logger.error(err);
+      this.logger.error(err);
 
       throw err;
     }

--- a/src/runtime/engine/flow_node_handler/intermediate_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_throw_event_handler.ts
@@ -37,8 +37,6 @@ export class IntermediateThrowEventHandler extends FlowNodeHandler<Model.Events.
 
   private _getChildHandler(): FlowNodeHandler<Model.Events.IntermediateCatchEvent> {
 
-    await this.persistOnEnter(token);
-
     if (this.flowNode.messageEventDefinition) {
       return this._container.resolve<FlowNodeHandler<Model.Events.IntermediateCatchEvent>>('IntermediateMessageThrowEventHandler', [this.flowNode]);
     }
@@ -47,71 +45,22 @@ export class IntermediateThrowEventHandler extends FlowNodeHandler<Model.Events.
       return this._container.resolve<FlowNodeHandler<Model.Events.IntermediateCatchEvent>>('IntermediateSignalThrowEventHandler', [this.flowNode]);
     }
 
-    return this._persistAndContinue(token, processTokenFacade, processModelFacade, identity);
+    throw new InternalServerError(`The IntermediateThrowEventType used with FlowNode ${this.flowNode.id} is not supported!`);
+  }
+
+  protected async executeInternally(token: Runtime.Types.ProcessToken,
+                                    processTokenFacade: IProcessTokenFacade,
+                                    processModelFacade: IProcessModelFacade,
+                                    identity: IIdentity): Promise<NextFlowNodeInfo> {
+
+    return this._childHandler.execute(token, processTokenFacade, processModelFacade, identity, this.previousFlowNodeInstanceId);
   }
 
   protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
                                    processTokenFacade: IProcessTokenFacade,
                                    processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                  ): Promise<NextFlowNodeInfo> {
+                                   identity: IIdentity): Promise<NextFlowNodeInfo> {
 
-    if (this.flowNode.messageEventDefinition) {
-      return this._resumeIntermediateThrowEventByType('IntermediateMessageThrowEventHandler',
-                                                      flowNodeInstance,
-                                                      processTokenFacade,
-                                                      processModelFacade,
-                                                     identity);
-    }
-
-    if (this.flowNode.signalEventDefinition) {
-      return this._resumeIntermediateThrowEventByType('IntermediateSignalThrowEventHandler',
-                                                      flowNodeInstance,
-                                                      processTokenFacade,
-                                                      processModelFacade,
-                                                      identity);
-    }
-
-    // The base handlers for IntermediateEvents only produce two tokens during their lifetime.
-    // Therefore, we can safely assume that token list will only contain one entry at this point.
-    const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
-
-    return this._persistAndContinue(onEnterToken, processTokenFacade, processModelFacade, identity);
-  }
-
-  private async _executeIntermediateThrowEventByType(eventHandlerName: string,
-                                                     token: Runtime.Types.ProcessToken,
-                                                     processTokenFacade: IProcessTokenFacade,
-                                                     processModelFacade: IProcessModelFacade,
-                                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
-
-    const eventHandler: FlowNodeHandler<Model.Events.IntermediateThrowEvent> =
-      await this._container.resolveAsync<FlowNodeHandler<Model.Events.IntermediateThrowEvent>>(eventHandlerName, [this.flowNode]);
-
-    return eventHandler.execute(token, processTokenFacade, processModelFacade, identity, this.previousFlowNodeInstanceId);
-  }
-
-  private async _resumeIntermediateThrowEventByType(eventHandlerName: string,
-                                                    flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                                    processTokenFacade: IProcessTokenFacade,
-                                                    processModelFacade: IProcessModelFacade,
-                                                    identity: IIdentity): Promise<NextFlowNodeInfo> {
-
-    const eventHandler: FlowNodeHandler<Model.Events.IntermediateCatchEvent> =
-      await this._container.resolveAsync<FlowNodeHandler<Model.Events.IntermediateCatchEvent>>(eventHandlerName, [this.flowNode]);
-
-    return eventHandler.resume(flowNodeInstance, processTokenFacade, processModelFacade, identity);
-  }
-
-  private async _persistAndContinue(token: Runtime.Types.ProcessToken,
-                                    processTokenFacade: IProcessTokenFacade,
-                                    processModelFacade: IProcessModelFacade,
-                                    identity: IIdentity): Promise<NextFlowNodeInfo> {
-
-    const nextFlowNodeInfo: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.flowNode);
-
-    await this.persistOnExit(token);
-
-    return new NextFlowNodeInfo(nextFlowNodeInfo, token, processTokenFacade);
+    return this._childHandler.resume(flowNodeInstance, processTokenFacade, processModelFacade, identity);
   }
 }

--- a/src/runtime/engine/flow_node_handler/intermediate_throw_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_throw_event_handler.ts
@@ -98,7 +98,7 @@ export class IntermediateThrowEventHandler extends FlowNodeHandler<Model.Events.
                                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
     const eventHandler: FlowNodeHandler<Model.Events.IntermediateCatchEvent> =
-      await this.container.resolveAsync<FlowNodeHandler<Model.Events.IntermediateCatchEvent>>(eventHandlerName, [this.flowNode]);
+      await this._container.resolveAsync<FlowNodeHandler<Model.Events.IntermediateCatchEvent>>(eventHandlerName, [this.flowNode]);
 
     return eventHandler.resume(flowNodeInstance, processTokenFacade, processModelFacade, identity);
   }

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -63,7 +63,7 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
       case Runtime.Types.FlowNodeInstanceState.suspended:
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
-        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
+        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
@@ -99,46 +99,19 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
     return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onSuspended" state.
-   *
-   * When the FlowNodeInstance was interrupted during this stage, we need to resubscribe
-   * to the EventHandler and wait for the ManualTasks result.
-   *
-   * @async
-   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
-   *                             suspended.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                     ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                       ): Promise<NextFlowNodeInfo> {
 
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onResumed" state.
-   *
-   * Basically, the ManualTask was already finished.
-   * The final result is only missing in the database.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                     processTokenFacade: IProcessTokenFacade,
-                                     processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.manualTask.id, resumeToken.payload);
     await this.persistOnExit(resumeToken);

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -51,57 +51,6 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
     return this._executeHandler(token, processTokenFacade, processModelFacade);
   }
 
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                  ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming FlowNodeInstance ${flowNodeInstance.id}.`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.suspended:
-        this.logger.verbose(`FlowNodeInstance was left suspended. Waiting for the ManualTask to be finished.`);
-        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
-
-        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.running:
-
-        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
-
-        const noMessageReceivedYet: boolean = resumeToken === undefined;
-        if (noMessageReceivedYet) {
-          this.logger.verbose(`FlowNodeInstance was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
-        }
-
-        this.logger.verbose(`The ManualTask was already finished and the handler resumed. Finishing up the handler.`);
-
-        return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`FlowNodeInstance was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-
-      default:
-        const invalidStateError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
-  }
-
   protected async _continueAfterEnter(onEnterToken: Runtime.Types.ProcessToken,
                                       processTokenFacade: IProcessTokenFacade,
                                       processModelFacade: IProcessModelFacade,

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -61,7 +61,6 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
@@ -76,11 +75,9 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
+      const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.manualTask.id, onExitToken);
-
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+      return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -158,11 +155,33 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
                                     ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.manualTask.id, resumeToken.payload);
-
     await this.persistOnExit(resumeToken);
-    this._sendManualTaskFinishedNotification(resumeToken);
 
     return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
+  }
+
+  /**
+   * Resumes the given FlowNodeInstance from the point where it assumed the
+   * "onExit" state.
+   *
+   * Basically, the handler had already finished.
+   * We just need to return the info about the next FlowNode to run.
+   *
+   * @async
+   * @param   resumeToken        The ProcessToken stored after resuming the
+   *                             FlowNodeInstance.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade,
+                                    ): Promise<NextFlowNodeInfo> {
+
+    processTokenFacade.addResultForFlowNode(this.manualTask.id, onExitToken.payload);
+
+    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
   }
 
   private async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -70,7 +70,9 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
 
         const noMessageReceivedYet: boolean = resumeToken === undefined;
         if (noMessageReceivedYet) {
-          return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
+          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+
+          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
@@ -87,26 +89,10 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
     }
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onEnter" state.
-   *
-   * Basically, the handler was not yet executed, except for the initial
-   * state change.
-   *
-   * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterEnter(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                    processTokenFacade: IProcessTokenFacade,
-                                    processModelFacade: IProcessModelFacade,
-                                   ): Promise<NextFlowNodeInfo> {
-
-    // When the FNI was interrupted directly after the onEnter state change, only one token will be present.
-    const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
+  protected async _continueAfterEnter(onEnterToken: Runtime.Types.ProcessToken,
+                                      processTokenFacade: IProcessTokenFacade,
+                                      processModelFacade: IProcessModelFacade,
+                                     ): Promise<NextFlowNodeInfo> {
 
     await this.persistOnSuspend(onEnterToken);
 
@@ -160,34 +146,10 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
     return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onExit" state.
-   *
-   * Basically, the handler had already finished.
-   * We just need to return the info about the next FlowNode to run.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.manualTask.id, onExitToken.payload);
-
-    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
-  }
-
-  private async _executeHandler(token: Runtime.Types.ProcessToken,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade,
-                               ): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade,
+                                 ): Promise<NextFlowNodeInfo> {
 
     const manualTaskResult: any = await this._waitForManualTaskResult(token);
     token.payload = manualTaskResult;

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -50,27 +50,41 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
   protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
                                    processTokenFacade: IProcessTokenFacade,
                                    processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity): Promise<NextFlowNodeInfo> {
+                                   identity: IIdentity,
+                                  ): Promise<NextFlowNodeInfo> {
+
+    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
+      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
+        return token.type === tokenType;
+      });
+    }
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        return this._continueAfterSuspend(flowNodeInstance, processTokenFacade, processModelFacade);
+
+        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+
+        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken =
-          flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-            return token.type === Runtime.Types.ProcessTokenType.onResume;
-          });
+        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
-        const manualTaskResultNotYetAwaited: boolean = resumeToken === undefined;
-
-        if (manualTaskResultNotYetAwaited) {
+        const noMessageReceivedYet: boolean = resumeToken === undefined;
+        if (noMessageReceivedYet) {
           return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+      case Runtime.Types.FlowNodeInstanceState.finished:
+
+        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        processTokenFacade.addResultForFlowNode(this.manualTask.id, onExitToken);
+
+        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
       default:
-        throw new InternalServerError(`Cannot resume ManualTask instance ${flowNodeInstance.id}, because it was already finished!`);
+        throw new InternalServerError(`Cannot resume ManualTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }
   }
 
@@ -108,22 +122,18 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
    * to the EventHandler and wait for the ManualTasks result.
    *
    * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
+   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
+   *                             suspended.
    * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
    * @param   processModelFacade The processModelFacade to use for resuming.
    * @returns                    The Info for the next FlowNode to run.
    */
-  private async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
                                       processTokenFacade: IProcessTokenFacade,
                                       processModelFacade: IProcessModelFacade,
                                      ): Promise<NextFlowNodeInfo> {
 
-    const suspendToken: Runtime.Types.ProcessToken =
-      flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === Runtime.Types.ProcessTokenType.onSuspend;
-      });
-
-    return this._executeHandler(suspendToken, processTokenFacade, processModelFacade);
+    return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
   /**

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -75,14 +75,16 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-      case Runtime.Types.FlowNodeInstanceState.terminated:
       case Runtime.Types.FlowNodeInstanceState.finished:
 
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
         processTokenFacade.addResultForFlowNode(this.manualTask.id, onExitToken);
 
         return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+        throw flowNodeInstance.error;
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+        throw new Error(`Cannot resume ManualTask instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume ManualTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -84,7 +84,7 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new Error(`Cannot resume ManualTask instance ${flowNodeInstance.id}, because it was terminated!`);
+        throw new InternalServerError(`Cannot resume ManualTask instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume ManualTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -1,3 +1,5 @@
+import {Logger} from 'loggerhythm';
+
 import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
@@ -30,6 +32,7 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
               manualTaskModel: Model.Activities.ManualTask) {
     super(flowNodeInstanceService, loggingApiService, metricsService, manualTaskModel);
     this._eventAggregator = eventAggregator;
+    this.logger = new Logger(`processengine:manual_task_handler:${manualTaskModel.id}`);
   }
 
   private get manualTask(): Model.Activities.ManualTask {
@@ -41,6 +44,7 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
+    this.logger.verbose(`Executing ManualTask instance ${this.flowNodeInstanceId}`);
     await this.persistOnEnter(token);
     await this.persistOnSuspend(token);
 
@@ -53,8 +57,11 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
+    this.logger.verbose(`Resuming FlowNodeInstance ${flowNodeInstance.id}.`);
+
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
+        this.logger.verbose(`FlowNodeInstance was left suspended. Waiting for the ManualTask to be finished.`);
         const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
@@ -64,22 +71,34 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
 
         const noMessageReceivedYet: boolean = resumeToken === undefined;
         if (noMessageReceivedYet) {
+          this.logger.verbose(`FlowNodeInstance was interrupted at the beginning. Resuming from the start.`);
           const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
+        this.logger.verbose(`The ManualTask was already finished and the handler resumed. Finishing up the handler.`);
+
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-      const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        this.logger.verbose(`FlowNodeInstance was already finished. Skipping ahead.`);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
-      return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
+        this.logger.error(`Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it previously exited with an error!`,
+                     flowNodeInstance.error);
         throw flowNodeInstance.error;
+
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new InternalServerError(`Cannot resume ManualTask instance ${flowNodeInstance.id}, because it was terminated!`);
+        const terminatedError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it was terminated!`;
+        this.logger.error(terminatedError);
+        throw new InternalServerError(terminatedError);
+
       default:
-        throw new InternalServerError(`Cannot resume ManualTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
+        const invalidStateError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because its state cannot be determined!`;
+        this.logger.error(invalidStateError);
+        throw new InternalServerError(invalidStateError);
     }
   }
 

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -53,31 +53,25 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
+        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const noMessageReceivedYet: boolean = resumeToken === undefined;
         if (noMessageReceivedYet) {
-          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-      const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+      const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
       return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -108,17 +108,6 @@ export class ManualTaskHandler extends FlowNodeHandler<Model.Activities.ManualTa
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                       processTokenFacade: IProcessTokenFacade,
-                                       processModelFacade: IProcessModelFacade,
-                                      ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.manualTask.id, resumeToken.payload);
-    await this.persistOnExit(resumeToken);
-
-    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
-  }
-
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade,

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handler.ts
@@ -63,6 +63,6 @@ export class ParallelGatewayHandler extends FlowNodeHandler<Model.Gateways.Paral
                                    processModelFacade: IProcessModelFacade,
                                    identity: IIdentity): Promise<NextFlowNodeInfo> {
 
-    return this._childEventHandler.resume(flowNodeInstance, processTokenFacade, processModelFacade, identity);
+    return this._childHandler.resume(flowNodeInstance, processTokenFacade, processModelFacade, identity);
   }
 }

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handler.ts
@@ -1,9 +1,10 @@
 import {IContainer} from 'addict-ioc';
+import * as moment from 'moment';
 
 import {UnprocessableEntityError} from '@essential-projects/errors_ts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
-import {ILoggingApi} from '@process-engine/logging_api_contracts';
+import {ILoggingApi, LogLevel} from '@process-engine/logging_api_contracts';
 import {IMetricsApi} from '@process-engine/metrics_api_contracts';
 import {
   IFlowNodeInstanceService,

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
@@ -22,7 +22,6 @@ export class ParallelJoinGatewayHandler extends FlowNodeHandler<Model.Gateways.P
               metricsService: IMetricsApi,
               parallelGatewayModel: Model.Gateways.ParallelGateway) {
     super(flowNodeInstanceService, loggingApiService, metricsService, parallelGatewayModel);
-
     this.logger = Logger.createLogger(`processengine:parallel_join_gateway:${parallelGatewayModel.id}`);
   }
 

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
@@ -14,23 +14,27 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-const logger: Logger = Logger.createLogger('processengine:runtime:parallel_join_gateway');
-
 import {FlowNodeHandler} from '../index';
 
 export class ParallelJoinGatewayHandler extends FlowNodeHandler<Model.Gateways.ParallelGateway> {
+
+  private logger: Logger;
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
               parallelGatewayModel: Model.Gateways.ParallelGateway) {
     super(flowNodeInstanceService, loggingApiService, metricsService, parallelGatewayModel);
+
+    this.logger = Logger.createLogger(`processengine:parallel_join_gateway:${parallelGatewayModel.id}`);
   }
 
   protected async executeInternally(token: Runtime.Types.ProcessToken,
                                     processTokenFacade: IProcessTokenFacade,
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
+
+    this.logger.verbose(`Executing ParallelJoinGateway instance ${this.flowNodeInstanceId}.`);
     await this.persistOnEnter(token);
 
     return await this._executeHandler(token, processTokenFacade, processModelFacade, identity);
@@ -48,31 +52,31 @@ export class ParallelJoinGatewayHandler extends FlowNodeHandler<Model.Gateways.P
       });
     }
 
-    logger.verbose(`Resuming ParallelJoinGateway ${flowNodeInstance.flowNodeId} with instance ID ${flowNodeInstance.id}.`);
+    this.logger.verbose(`Resuming ParallelJoinGateway instance ${flowNodeInstance.id}.`);
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
-        logger.verbose(`ParallelJoinGateway was unfinished. Resuming from the start.`);
+        this.logger.verbose(`ParallelJoinGateway was unfinished. Resuming from the start.`);
         const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.finished:
-        logger.verbose(`ParallelJoinGateway was already finished. Skipping ahead.`);
+        this.logger.verbose(`ParallelJoinGateway was already finished. Skipping ahead.`);
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
-        logger.error(`Cannot resume ParallelJoinGateway instance ${flowNodeInstance.id}, because it previously exited with an error!`,
+        this.logger.error(`Cannot resume ParallelJoinGateway instance ${flowNodeInstance.id}, because it previously exited with an error!`,
                      flowNodeInstance.error);
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
         const terminatedError: string = `Cannot resume ParallelJoinGateway instance ${flowNodeInstance.id}, because it was terminated!`;
-        logger.error(terminatedError);
+        this.logger.error(terminatedError);
         throw new InternalServerError(terminatedError);
       default:
         const invalidStateError: string =
           `Cannot resume ParallelJoinGateway instance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        logger.error(invalidStateError);
+        this.logger.error(invalidStateError);
         throw new InternalServerError(invalidStateError);
     }
   }

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
@@ -46,23 +46,17 @@ export class ParallelJoinGatewayHandler extends FlowNodeHandler<Model.Gateways.P
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     this.logger.verbose(`Resuming ParallelJoinGateway instance ${flowNodeInstance.id}.`);
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
         this.logger.verbose(`ParallelJoinGateway was unfinished. Resuming from the start.`);
-        const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.finished:
         this.logger.verbose(`ParallelJoinGateway was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
@@ -1,4 +1,6 @@
-import {UnprocessableEntityError} from '@essential-projects/errors_ts';
+import {Logger} from 'loggerhythm';
+
+import {InternalServerError} from '@essential-projects/errors_ts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {ILoggingApi} from '@process-engine/logging_api_contracts';
@@ -11,6 +13,8 @@ import {
   NextFlowNodeInfo,
   Runtime,
 } from '@process-engine/process_engine_contracts';
+
+const logger: Logger = Logger.createLogger('processengine:runtime:parallel_join_gateway');
 
 import {FlowNodeHandler} from '../index';
 
@@ -28,6 +32,55 @@ export class ParallelJoinGatewayHandler extends FlowNodeHandler<Model.Gateways.P
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
     await this.persistOnEnter(token);
+
+    return await this._executeHandler(token, processTokenFacade, processModelFacade, identity);
+  }
+
+  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade,
+                                   identity: IIdentity,
+                                  ): Promise<NextFlowNodeInfo> {
+
+    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
+      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
+        return token.type === tokenType;
+      });
+    }
+
+    logger.verbose(`Resuming ParallelJoinGateway ${flowNodeInstance.flowNodeId} with instance ID ${flowNodeInstance.id}.`);
+
+    switch (flowNodeInstance.state) {
+      case Runtime.Types.FlowNodeInstanceState.running:
+        logger.verbose(`ParallelJoinGateway was unfinished. Resuming from the start.`);
+        const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+
+        return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
+      case Runtime.Types.FlowNodeInstanceState.finished:
+        logger.verbose(`ParallelJoinGateway was already finished. Skipping ahead.`);
+        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+        logger.error(`Cannot resume ParallelJoinGateway instance ${flowNodeInstance.id}, because it previously exited with an error!`,
+                     flowNodeInstance.error);
+        throw flowNodeInstance.error;
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+        const terminatedError: string = `Cannot resume ParallelJoinGateway instance ${flowNodeInstance.id}, because it was terminated!`;
+        logger.error(terminatedError);
+        throw new InternalServerError(terminatedError);
+      default:
+        const invalidStateError: string =
+          `Cannot resume ParallelJoinGateway instance ${flowNodeInstance.id}, because its state cannot be determined!`;
+        logger.error(invalidStateError);
+        throw new InternalServerError(invalidStateError);
+    }
+  }
+
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade,
+                                  identity: IIdentity): Promise<NextFlowNodeInfo> {
     await this.persistOnExit(token);
 
     return this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
@@ -1,6 +1,5 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {ILoggingApi} from '@process-engine/logging_api_contracts';
@@ -17,8 +16,6 @@ import {
 import {FlowNodeHandler} from '../index';
 
 export class ParallelJoinGatewayHandler extends FlowNodeHandler<Model.Gateways.ParallelGateway> {
-
-  private logger: Logger;
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
@@ -38,41 +35,6 @@ export class ParallelJoinGatewayHandler extends FlowNodeHandler<Model.Gateways.P
     await this.persistOnEnter(token);
 
     return await this._executeHandler(token, processTokenFacade, processModelFacade, identity);
-  }
-
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                  ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming ParallelJoinGateway instance ${flowNodeInstance.id}.`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.running:
-        this.logger.verbose(`ParallelJoinGateway was unfinished. Resuming from the start.`);
-        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-        return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`ParallelJoinGateway was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume ParallelJoinGateway instance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume ParallelJoinGateway instance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-      default:
-        const invalidStateError: string =
-          `Cannot resume ParallelJoinGateway instance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
   }
 
   protected async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
@@ -304,9 +304,10 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
 
     const resumingNotFinished: boolean = flowNodeInstanceForNextFlowNode !== undefined;
     if (resumingNotFinished) {
-      this.logger.info(`Resuming FlowNode ${flowNodeInstanceForNextFlowNode.flowNodeId} for ParallelGateway instance ${this.flowNodeInstanceId}.`);
       // If a matching FlowNodeInstance exists, continue resuming.
-      await this._resumeBranchToJoinGateway(nextFlowNodeInfo.flowNode,
+      this.logger.info(`Resuming FlowNode ${flowNodeInstanceForNextFlowNode.flowNodeId} for ParallelGateway instance ${this.flowNodeInstanceId}.`);
+
+      return this._resumeBranchToJoinGateway(nextFlowNodeInfo.flowNode,
                                             flowNodeInstanceForNextFlowNode,
                                             joinGateway,
                                             nextFlowNodeInfo.token,
@@ -314,20 +315,20 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
                                             processModelFacade,
                                             identity,
                                             flowNodeInstancesForProcessInstance);
-    } else {
-      // Otherwise, we will have arrived at the point at which the branch was previously interrupted,
-      // and we can continue with normal execution.
-      this.logger.info(`All interrupted FlowNodeInstances resumed and finished.`);
-      this.logger.info(`Continuing parallel branch in ParallelGateway instance ${this.flowNodeInstanceId} normally.`);
-      await this._executeBranchToJoinGateway(nextFlowNodeInfo.flowNode,
-                                             joinGateway,
-                                             nextFlowNodeInfo.token,
-                                             nextFlowNodeInfo.processTokenFacade,
-                                             processModelFacade,
-                                             identity,
-                                             flowNodeInstanceForFlowNode.id);
     }
 
+    // Otherwise, we will have arrived at the point at which the branch was previously interrupted,
+    // and we can continue with normal execution.
+    this.logger.info(`All interrupted FlowNodeInstances resumed and finished.`);
+    this.logger.info(`Continuing parallel branch in ParallelGateway instance ${this.flowNodeInstanceId} normally.`);
+
+    return this._executeBranchToJoinGateway(nextFlowNodeInfo.flowNode,
+                                           joinGateway,
+                                           nextFlowNodeInfo.token,
+                                           nextFlowNodeInfo.processTokenFacade,
+                                           processModelFacade,
+                                           identity,
+                                           flowNodeInstanceForFlowNode.id);
   }
 
   private async _mergeTokenHistories(processTokenFacade: IProcessTokenFacade,

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
@@ -76,19 +76,23 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
         const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
+
       case Runtime.Types.FlowNodeInstanceState.finished:
         this.logger.verbose(`ParallelSplitGateway was finished. Reconstructing branches.`);
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade, identity);
+
       case Runtime.Types.FlowNodeInstanceState.error:
         this.logger.error(`Cannot resume ParallelSplitGateway instance ${flowNodeInstance.id}, because it previously exited with an error!`,
                      flowNodeInstance.error);
         throw flowNodeInstance.error;
+
       case Runtime.Types.FlowNodeInstanceState.terminated:
         const terminatedError: string = `Cannot resume ParallelSplitGateway instance ${flowNodeInstance.id}, because it was terminated!`;
         this.logger.error(terminatedError);
         throw new InternalServerError(terminatedError);
+
       default:
         const invalidStateError: string =
           `Cannot resume ParallelSplitGateway instance ${flowNodeInstance.id}, because its state cannot be determined!`;

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
@@ -83,6 +83,7 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
         logger.error(`Cannot resume ParallelSplitGateway instance ${flowNodeInstance.id}, because it previously exited with an error!`,
                      flowNodeInstance.error);
         throw flowNodeInstance.error;
+      case Runtime.Types.FlowNodeInstanceState.terminated:
         const terminatedError: string = `Cannot resume ParallelSplitGateway instance ${flowNodeInstance.id}, because it was terminated!`;
         logger.error(terminatedError);
         throw new InternalServerError(terminatedError);

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
@@ -288,10 +288,9 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
       throw new InternalServerError(`Process was terminated through TerminateEndEvent "${this._processTerminatedMessage.flowNodeId}".`);
     }
 
-    // If the next FlowNode is the JoinGateway for this branch, then the branch has finished.
-    const nextFlowNodeIsJoinGateway: boolean =
-      nextFlowNodeInfo.flowNode !== null && nextFlowNodeInfo.flowNode && nextFlowNodeInfo.flowNode.id !== joinGateway.id;
-    if (nextFlowNodeIsJoinGateway) {
+    // If no next FlowNode exists, or the next FlowNode is the JoinGateway for this branch, then the branch has finished.
+    const stopExecution: boolean = !nextFlowNodeInfo.flowNode || nextFlowNodeInfo.flowNode.id === joinGateway.id;
+    if (stopExecution) {
       return new NextFlowNodeInfo(joinGateway, nextFlowNodeInfo.token, nextFlowNodeInfo.processTokenFacade);
     }
 

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
@@ -138,7 +138,7 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
 
     // After all parallel branches have finished, the collective results are merged into the ProcessTokenFacade.
     const mergedToken: Runtime.Types.ProcessToken = await this._mergeTokenHistories(processTokenFacade, nextFlowNodeInfos);
-    logger.verbose(`Finished ${nextFlowNodeInfos.length} parallel branches with final result:`, mergedToken);
+    logger.verbose(`Finished ${nextFlowNodeInfos.length} parallel branches with final result:`, mergedToken.payload);
 
     return new NextFlowNodeInfo(joinGateway, mergedToken, processTokenFacade);
   }
@@ -169,7 +169,7 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
 
     // After all parallel branches have finished, the collective results are merged into the ProcessTokenFacade.
     const mergedToken: Runtime.Types.ProcessToken = await this._mergeTokenHistories(processTokenFacade, nextFlowNodeInfos);
-    logger.verbose(`Finished ${nextFlowNodeInfos.length} parallel branches with final result:`, mergedToken);
+    logger.verbose(`Finished ${nextFlowNodeInfos.length} parallel branches with final result:`, mergedToken.payload);
 
     return new NextFlowNodeInfo(joinGateway, mergedToken, processTokenFacade);
   }

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
@@ -62,24 +62,18 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     this.logger.verbose(`Resuming ParallelSplitGateway instance ${flowNodeInstance.id}.`);
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
         this.logger.verbose(`ParallelSplitGateway was unfinished. Resuming from the start.`);
-        const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
 
       case Runtime.Types.FlowNodeInstanceState.finished:
         this.logger.verbose(`ParallelSplitGateway was finished. Reconstructing branches.`);
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade, identity);
 

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -59,7 +59,7 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
       case Runtime.Types.FlowNodeInstanceState.suspended:
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
-        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
+        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
@@ -85,45 +85,19 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
     }
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onSuspended" state.
-   *
-   * When the FlowNodeInstance was interrupted during this stage, we need to
-   * run the handler again, except for the "onSuspend" state change.
-   *
-   * @async
-   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
-   *                             suspended.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                     ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                       ): Promise<NextFlowNodeInfo> {
 
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onResumed" state.
-   *
-   * Basically, the ReceiveTask was already finished.
-   * The final result is only missing in the database.
-   *
-   * @async
-   * @param   resumeToken   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                     processTokenFacade: IProcessTokenFacade,
-                                     processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.receiveTask.id, resumeToken.payload);
     await this.persistOnExit(resumeToken);

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -57,7 +57,6 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
@@ -72,11 +71,9 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.receiveTask.id, onExitToken);
 
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -151,12 +148,33 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
                                     ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.receiveTask.id, resumeToken.payload);
-
-    const nextNodeAfter: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.receiveTask);
-
     await this.persistOnExit(resumeToken);
 
-    return new NextFlowNodeInfo(nextNodeAfter, resumeToken, processTokenFacade);
+    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
+  }
+
+  /**
+   * Resumes the given FlowNodeInstance from the point where it assumed the
+   * "onExit" state.
+   *
+   * Basically, the handler had already finished.
+   * We just need to return the info about the next FlowNode to run.
+   *
+   * @async
+   * @param   resumeToken        The ProcessToken stored after resuming the
+   *                             FlowNodeInstance.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade,
+                                    ): Promise<NextFlowNodeInfo> {
+
+    processTokenFacade.addResultForFlowNode(this.receiveTask.id, onExitToken.payload);
+
+    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
   }
 
   private async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -94,17 +94,6 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                       processTokenFacade: IProcessTokenFacade,
-                                       processModelFacade: IProcessModelFacade,
-                                      ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.receiveTask.id, resumeToken.payload);
-    await this.persistOnExit(resumeToken);
-
-    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
-  }
-
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -80,7 +80,7 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new Error(`Cannot resume ReceiveTask instance ${flowNodeInstance.id}, because it was terminated!`);
+        throw new InternalServerError(`Cannot resume ReceiveTask instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume ReceiveTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -49,25 +49,38 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
+    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
+      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
+        return token.type === tokenType;
+      });
+    }
+
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        return this._continueAfterSuspend(flowNodeInstance, processTokenFacade, processModelFacade);
+
+        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+
+        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken =
-          flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-            return token.type === Runtime.Types.ProcessTokenType.onResume;
-          });
+        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
-        const receiveTaskNotYetTriggered: boolean = resumeToken === undefined;
-
-        if (receiveTaskNotYetTriggered) {
+        const noMessageReceivedYet: boolean = resumeToken === undefined;
+        if (noMessageReceivedYet) {
           return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+      case Runtime.Types.FlowNodeInstanceState.finished:
+
+        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        processTokenFacade.addResultForFlowNode(this.receiveTask.id, onExitToken);
+
+        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
       default:
-        throw new InternalServerError(`Cannot resume ReceiveTask instance ${flowNodeInstance.id}, because it was already finished!`);
+        throw new InternalServerError(`Cannot resume ReceiveTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }
   }
 
@@ -103,22 +116,18 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
    * run the handler again, except for the "onSuspend" state change.
    *
    * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
+   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
+   *                             suspended.
    * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
    * @param   processModelFacade The processModelFacade to use for resuming.
    * @returns                    The Info for the next FlowNode to run.
    */
-  private async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
                                       processTokenFacade: IProcessTokenFacade,
                                       processModelFacade: IProcessModelFacade,
                                      ): Promise<NextFlowNodeInfo> {
 
-    const suspendToken: Runtime.Types.ProcessToken =
-      flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === Runtime.Types.ProcessTokenType.onSuspend;
-      });
-
-    return this._executeHandler(suspendToken, processTokenFacade, processModelFacade);
+    return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
   /**

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -66,7 +66,9 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
 
         const noMessageReceivedYet: boolean = resumeToken === undefined;
         if (noMessageReceivedYet) {
-          return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
+          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+
+          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
@@ -81,30 +83,6 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
       default:
         throw new InternalServerError(`Cannot resume ReceiveTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }
-  }
-
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onEnter" state.
-   *
-   * Basically, the handler was not yet executed, except for the initial
-   * state change.
-   *
-   * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterEnter(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                    processTokenFacade: IProcessTokenFacade,
-                                    processModelFacade: IProcessModelFacade,
-                                   ): Promise<NextFlowNodeInfo> {
-
-    // When the FNI was interrupted directly after the onEnter state change, only one token will be present.
-    const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
-
-    return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);
   }
 
   /**
@@ -153,33 +131,9 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
     return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onExit" state.
-   *
-   * Basically, the handler had already finished.
-   * We just need to return the info about the next FlowNode to run.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.receiveTask.id, onExitToken.payload);
-
-    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
-  }
-
-  private async _executeHandler(token: Runtime.Types.ProcessToken,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
     const receivedMessage: MessageEventReachedMessage = await this._waitForMessage();
     await this.persistOnResume(token);

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -71,14 +71,16 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-      case Runtime.Types.FlowNodeInstanceState.terminated:
       case Runtime.Types.FlowNodeInstanceState.finished:
 
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
         processTokenFacade.addResultForFlowNode(this.receiveTask.id, onExitToken);
 
         return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+        throw flowNodeInstance.error;
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+        throw new Error(`Cannot resume ReceiveTask instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume ReceiveTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -49,31 +49,25 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
+        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const noMessageReceivedYet: boolean = resumeToken === undefined;
         if (noMessageReceivedYet) {
-          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -47,57 +47,6 @@ export class ReceiveTaskHandler extends FlowNodeHandler<Model.Activities.Receive
     return this._executeHandler(token, processTokenFacade, processModelFacade);
   }
 
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                  ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming FlowNodeInstance ${flowNodeInstance.id}.`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.suspended:
-        this.logger.verbose(`FlowNodeInstance was left suspended. Waiting to receive a message from a SendTask.`);
-        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
-
-        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.running:
-
-        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
-
-        const noMessageReceivedYet: boolean = resumeToken === undefined;
-        if (noMessageReceivedYet) {
-          this.logger.verbose(`FlowNodeInstance was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
-        }
-
-        this.logger.verbose(`The ReceiveTask already sent a response and the handler was resumed. Finishing up the handler.`);
-
-        return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`FlowNodeInstance was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-
-      default:
-        const invalidStateError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
-  }
-
   protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
                                         onSuspendToken: Runtime.Types.ProcessToken,
                                         processTokenFacade: IProcessTokenFacade,

--- a/src/runtime/engine/flow_node_handler/script_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/script_task_handler.ts
@@ -65,7 +65,7 @@ export class ScriptTaskHandler extends FlowNodeHandler<Model.Activities.ScriptTa
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new Error(`Cannot resume ScriptTask instance ${flowNodeInstance.id}, because it was terminated!`);
+        throw new InternalServerError(`Cannot resume ScriptTask instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume ScriptTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/script_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/script_task_handler.ts
@@ -54,13 +54,11 @@ export class ScriptTaskHandler extends FlowNodeHandler<Model.Activities.ScriptTa
       case Runtime.Types.FlowNodeInstanceState.running:
         const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
-        return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade, identity);
+        return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.finished:
-
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.scriptTask.id, onExitToken.payload);
 
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -70,11 +68,11 @@ export class ScriptTaskHandler extends FlowNodeHandler<Model.Activities.ScriptTa
     }
   }
 
-  private async _executeHandler(token: Runtime.Types.ProcessToken,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade,
-                                identity: IIdentity,
-                              ): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade,
+                                  identity: IIdentity,
+                                 ): Promise<NextFlowNodeInfo> {
 
     let result: any = {};
 

--- a/src/runtime/engine/flow_node_handler/script_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/script_task_handler.ts
@@ -44,19 +44,13 @@ export class ScriptTaskHandler extends FlowNodeHandler<Model.Activities.ScriptTa
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
-        const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.finished:
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/script_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/script_task_handler.ts
@@ -56,14 +56,16 @@ export class ScriptTaskHandler extends FlowNodeHandler<Model.Activities.ScriptTa
         const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade, identity);
-      case Runtime.Types.FlowNodeInstanceState.error:
-      case Runtime.Types.FlowNodeInstanceState.terminated:
       case Runtime.Types.FlowNodeInstanceState.finished:
 
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
         processTokenFacade.addResultForFlowNode(this.scriptTask.id, onExitToken);
 
         return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+        throw flowNodeInstance.error;
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+        throw new Error(`Cannot resume ScriptTask instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume ScriptTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/script_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/script_task_handler.ts
@@ -52,14 +52,13 @@ export class ScriptTaskHandler extends FlowNodeHandler<Model.Activities.ScriptTa
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
-
         const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.finished:
 
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.scriptTask.id, onExitToken);
+        processTokenFacade.addResultForFlowNode(this.scriptTask.id, onExitToken.payload);
 
         return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -60,7 +60,7 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
       case Runtime.Types.FlowNodeInstanceState.suspended:
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
-        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
+        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
@@ -86,45 +86,19 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
     }
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onSuspended" state.
-   *
-   * When the FlowNodeInstance was interrupted during this stage, we need to
-   * run the handler again, except for the "onSuspend" state change.
-   *
-   * @async
-   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
-   *                             suspended.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                     ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                       ): Promise<NextFlowNodeInfo> {
 
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onResumed" state.
-   *
-   * Basically, the ReceiveTask was already finished.
-   * The final result is only missing in the database.
-   *
-   * @async
-   * @param   resumeToken   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                     processTokenFacade: IProcessTokenFacade,
-                                     processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.sendTask.id, resumeToken.payload);
     await this.persistOnExit(resumeToken);

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -48,57 +48,6 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
     return this._executeHandler(token, processTokenFacade, processModelFacade);
   }
 
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                  ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming FlowNodeInstance ${flowNodeInstance.id}.`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.suspended:
-        this.logger.verbose(`FlowNodeInstance was left suspended. Waiting for the SendTask to receive a response.`);
-        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
-
-        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.running:
-
-        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
-
-        const noResponseReceivedYet: boolean = resumeToken === undefined;
-        if (noResponseReceivedYet) {
-          this.logger.verbose(`FlowNodeInstance was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
-        }
-
-        this.logger.verbose(`The SendTask already received a response and the handler was resumed. Finishing up the handler.`);
-
-        return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`FlowNodeInstance was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-
-      default:
-        const invalidStateError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
-  }
-
   protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
                                         onSuspendToken: Runtime.Types.ProcessToken,
                                         processTokenFacade: IProcessTokenFacade,

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -50,31 +50,25 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
+        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const noResponseReceivedYet: boolean = resumeToken === undefined;
         if (noResponseReceivedYet) {
-          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -50,25 +50,38 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
+    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
+      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
+        return token.type === tokenType;
+      });
+    }
+
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        return this._continueAfterSuspend(flowNodeInstance, processTokenFacade, processModelFacade);
+
+        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+
+        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken =
-          flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-            return token.type === Runtime.Types.ProcessTokenType.onResume;
-          });
+        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
-        const receiveTaskNotYetTriggered: boolean = resumeToken === undefined;
-
-        if (receiveTaskNotYetTriggered) {
+        const noResponseReceivedYet: boolean = resumeToken === undefined;
+        if (noResponseReceivedYet) {
           return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+      case Runtime.Types.FlowNodeInstanceState.finished:
+
+        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        processTokenFacade.addResultForFlowNode(this.sendTask.id, onExitToken);
+
+        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
       default:
-        throw new InternalServerError(`Cannot resume ReceiveTask instance ${flowNodeInstance.id}, because it was already finished!`);
+        throw new InternalServerError(`Cannot resume SendTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }
   }
 
@@ -104,22 +117,18 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
    * run the handler again, except for the "onSuspend" state change.
    *
    * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
+   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
+   *                             suspended.
    * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
    * @param   processModelFacade The processModelFacade to use for resuming.
    * @returns                    The Info for the next FlowNode to run.
    */
-  private async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
                                       processTokenFacade: IProcessTokenFacade,
                                       processModelFacade: IProcessModelFacade,
                                      ): Promise<NextFlowNodeInfo> {
 
-    const suspendToken: Runtime.Types.ProcessToken =
-      flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === Runtime.Types.ProcessTokenType.onSuspend;
-      });
-
-    return this._executeHandler(suspendToken, processTokenFacade, processModelFacade);
+    return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
   /**
@@ -141,12 +150,9 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
                                     ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.sendTask.id, resumeToken.payload);
-
-    const nextNodeAfter: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.sendTask);
-
     await this.persistOnExit(resumeToken);
 
-    return new NextFlowNodeInfo(nextNodeAfter, resumeToken, processTokenFacade);
+    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
   }
 
   private async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -81,7 +81,7 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new Error(`Cannot resume SendTask instance ${flowNodeInstance.id}, because it was terminated!`);
+        throw new InternalServerError(`Cannot resume SendTask instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume SendTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -58,7 +58,6 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
@@ -73,11 +72,9 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.sendTask.id, onExitToken);
 
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -155,6 +152,30 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
     await this.persistOnExit(resumeToken);
 
     return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
+  }
+
+  /**
+   * Resumes the given FlowNodeInstance from the point where it assumed the
+   * "onExit" state.
+   *
+   * Basically, the handler had already finished.
+   * We just need to return the info about the next FlowNode to run.
+   *
+   * @async
+   * @param   resumeToken        The ProcessToken stored after resuming the
+   *                             FlowNodeInstance.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade,
+                                    ): Promise<NextFlowNodeInfo> {
+
+    processTokenFacade.addResultForFlowNode(this.sendTask.id, onExitToken.payload);
+
+    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
   }
 
   private async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -72,14 +72,16 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-      case Runtime.Types.FlowNodeInstanceState.terminated:
       case Runtime.Types.FlowNodeInstanceState.finished:
 
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
         processTokenFacade.addResultForFlowNode(this.sendTask.id, onExitToken);
 
         return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+        throw flowNodeInstance.error;
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+        throw new Error(`Cannot resume SendTask instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume SendTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -95,17 +95,6 @@ export class SendTaskHandler extends FlowNodeHandler<Model.Activities.SendTask> 
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                       processTokenFacade: IProcessTokenFacade,
-                                       processModelFacade: IProcessModelFacade,
-                                      ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.sendTask.id, resumeToken.payload);
-    await this.persistOnExit(resumeToken);
-
-    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
-  }
-
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade,

--- a/src/runtime/engine/flow_node_handler/service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handler.ts
@@ -58,7 +58,7 @@ export class ServiceTaskHandler extends FlowNodeHandler<Model.Activities.Service
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
-    return this._childEventHandler.execute(token, processTokenFacade, processModelFacade, identity, this.previousFlowNodeInstanceId);
+    return this._childServiceTaskHandler.execute(token, processTokenFacade, processModelFacade, identity, this.previousFlowNodeInstanceId);
   }
 
   protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
@@ -136,6 +136,6 @@ export class ServiceTaskHandler extends FlowNodeHandler<Model.Activities.Service
     } catch (error) {
       logger.info('No external task has been stored for this FlowNodeInstance.');
 
-    return this._childEventHandler.resume(flowNodeInstance, processTokenFacade, processModelFacade, identity);
+    return this._childServiceTaskHandler.resume(flowNodeInstance, processTokenFacade, processModelFacade, identity);
   }
 }

--- a/src/runtime/engine/flow_node_handler/service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handler.ts
@@ -49,8 +49,6 @@ export class ServiceTaskHandler extends FlowNodeHandler<Model.Activities.Service
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
-    await this.persistOnEnter(token);
-
     if (this.serviceTask.type === Model.Activities.ServiceTaskType.external) {
       return this._executeServiceTaskByType('ExternalServiceTaskHandler', token, processTokenFacade, processModelFacade, identity);
     }

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -187,7 +187,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
 
       const externalTaskIsAlreadyFinished: boolean = externalTask.state === ExternalTaskState.finished;
       if (externalTaskIsAlreadyFinished) {
-        // The external worker has alrady finished processing the ExternalTask
+        // The external worker has already finished processing the ExternalTask
         // and we only missed the notification.
         // We can continue with the ExternalTask we retrieved from the database.
         processExternalTaskResult(externalTask.error, externalTask.result);

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -168,17 +168,6 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
     });
   }
 
-  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                       processTokenFacade: IProcessTokenFacade,
-                                       processModelFacade: IProcessModelFacade,
-                                      ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.serviceTask.id, resumeToken.payload);
-    await this.persistOnExit(resumeToken);
-
-    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
-  }
-
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade,

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -108,38 +108,18 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
     }
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onSuspended" state.
-   *
-   * When the FlowNodeInstance was interrupted during this stage, we need to resubscribe
-   * to the EventHandler and wait for the ServiceTasks result.
-   *
-   * We also need to check if the ExternalTask was already executed during the downtime.
-   * If it was, we need to resume and finish manually and NOT create a new external task!
-   * Otherwise, the ExternalTask might get executed twice.
-   *
-   * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
-   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
-   *                             suspended.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                      onSuspendToken: Runtime.Types.ProcessToken,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                      identity: IIdentity,
-                                     ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                        identity: IIdentity,
+                                       ): Promise<NextFlowNodeInfo> {
 
     return new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
       const externalTask: ExternalTask<any> = await this._getExternalTaskForFlowNodeInstance(flowNodeInstance);
 
       const noMatchingExteralTaskExists: boolean = !externalTask;
-
       if (noMatchingExteralTaskExists) {
         // No ExternalTask has been created yet. We can just execute the normal handler method chain.
         const result: any = await this._executeExternalServiceTask(onSuspendToken, processTokenFacade, identity);
@@ -185,28 +165,13 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
         // We must wait for the notification and pass the result to our customized callback.
         this._waitForExternalTaskResult(processExternalTaskResult);
       }
-
     });
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onResumed" state.
-   *
-   * Basically, the ServiceTask was already finished, but the final state change
-   * didn't happen.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                     processTokenFacade: IProcessTokenFacade,
-                                     processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.serviceTask.id, resumeToken.payload);
     await this.persistOnExit(resumeToken);

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -23,8 +23,6 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
   private _eventAggregator: IEventAggregator;
   private _externalTaskRepository: IExternalTaskRepository;
 
-  private logger: Logger;
-
   constructor(eventAggregator: IEventAggregator,
               externalTaskRepository: IExternalTaskRepository,
               flowNodeInstanceService: IFlowNodeInstanceService,

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -53,55 +53,6 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
     return this._executeHandler(token, processTokenFacade, processModelFacade, identity);
   }
 
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                  ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming external ServiceTask instance ${flowNodeInstance.id}`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.suspended:
-        this.logger.verbose(`ServiceTask was left suspended. Waiting for the ExternalTask to be processed.`);
-        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
-
-        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade, identity);
-      case Runtime.Types.FlowNodeInstanceState.running:
-
-        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
-
-        const noMessageReceivedYet: boolean = resumeToken === undefined;
-        if (noMessageReceivedYet) {
-          this.logger.verbose(`ServiceTask was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
-        }
-
-        this.logger.verbose(`The external task was already processed and the handler resumed. Finishing up the handler.`);
-
-        return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`ServiceTask was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume ServiceTask instance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume ServiceTask instance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-      default:
-        const invalidStateError: string = `Cannot resume ServiceTask instance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
-  }
-
   protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
                                         onSuspendToken: Runtime.Types.ProcessToken,
                                         processTokenFacade: IProcessTokenFacade,

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -61,28 +61,22 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     this.logger.verbose(`Resuming external ServiceTask instance ${flowNodeInstance.id}`);
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
         this.logger.verbose(`ServiceTask was left suspended. Waiting for the ExternalTask to be processed.`);
-        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
+        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const noMessageReceivedYet: boolean = resumeToken === undefined;
         if (noMessageReceivedYet) {
           this.logger.verbose(`ServiceTask was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
         }
@@ -92,7 +86,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
         this.logger.verbose(`ServiceTask was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -21,8 +21,6 @@ export class InternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
 
   private _container: IContainer;
 
-  private logger: Logger;
-
   constructor(container: IContainer,
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
@@ -49,40 +47,6 @@ export class InternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
     await this.persistOnEnter(token);
 
     return this._executeHandler(token, processTokenFacade, processModelFacade, identity);
-  }
-
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                  ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming internal ServiceTask instance ${flowNodeInstance.id}.`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.running:
-        this.logger.verbose(`ServiceTask was unfinished. Resuming from the start.`);
-        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-        return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`ServiceTask was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume ServiceTask instance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume ServiceTask instance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-      default:
-        const invalidStateError: string = `Cannot resume ServiceTask instance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
   }
 
   protected async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -68,14 +68,12 @@ export class InternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
         logger.verbose(`ServiceTask was unfinished. Resuming from the start.`);
         const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
-        return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade, identity);
+        return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.finished:
         logger.verbose(`ServiceTask was already finished. Skipping ahead.`);
-
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.serviceTask.id, onExitToken);
 
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         logger.error(`Cannot resume ServiceTask instance ${flowNodeInstance.id}, because it previously exited with an error!`,
                      flowNodeInstance.error);
@@ -91,11 +89,11 @@ export class InternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
     }
   }
 
-  private async _executeHandler(token: Runtime.Types.ProcessToken,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade,
-                                identity: IIdentity,
-                               ): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade,
+                                  identity: IIdentity,
+                                 ): Promise<NextFlowNodeInfo> {
 
     let result: any;
 

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -57,23 +57,17 @@ export class InternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     this.logger.verbose(`Resuming internal ServiceTask instance ${flowNodeInstance.id}.`);
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.running:
         this.logger.verbose(`ServiceTask was unfinished. Resuming from the start.`);
-        const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+        const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
         return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.finished:
         this.logger.verbose(`ServiceTask was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/start_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/start_event_handler.ts
@@ -80,14 +80,16 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-      case Runtime.Types.FlowNodeInstanceState.terminated:
       case Runtime.Types.FlowNodeInstanceState.finished:
 
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
         processTokenFacade.addResultForFlowNode(this.startEvent.id, onExitToken);
 
         return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+        throw flowNodeInstance.error;
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+        throw new Error(`Cannot resume StartEvent instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume StartEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/start_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/start_event_handler.ts
@@ -51,21 +51,27 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
     return this._executeHandler(token, processTokenFacade, processModelFacade);
   }
 
-  public async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade,
-                                identity: IIdentity,
-                              ): Promise<NextFlowNodeInfo> {
+  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade,
+                                   identity: IIdentity,
+                                 ): Promise<NextFlowNodeInfo> {
+
+    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
+      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
+        return token.type === tokenType;
+      });
+    }
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        return this._continueAfterSuspend(flowNodeInstance, processTokenFacade, processModelFacade);
+
+        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+
+        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken =
-          flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-            return token.type === Runtime.Types.ProcessTokenType.onResume;
-          });
+        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const startEventConditionNotYetAchieved: boolean = resumeToken === undefined;
 
@@ -74,8 +80,16 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+      case Runtime.Types.FlowNodeInstanceState.finished:
+
+        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        processTokenFacade.addResultForFlowNode(this.startEvent.id, onExitToken);
+
+        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
       default:
-        throw new InternalServerError(`Cannot resume StartEvent instance ${flowNodeInstance.id}, because it was already finished!`);
+        throw new InternalServerError(`Cannot resume StartEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }
   }
 
@@ -111,20 +125,16 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
    * run the handler again, except for the "onSuspend" state change.
    *
    * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
+   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
+   *                             suspended.
    * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
    * @param   processModelFacade The processModelFacade to use for resuming.
    * @returns                    The Info for the next FlowNode to run.
    */
-  private async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
                                       processTokenFacade: IProcessTokenFacade,
                                       processModelFacade: IProcessModelFacade,
                                      ): Promise<NextFlowNodeInfo> {
-
-    const onSuspendToken: Runtime.Types.ProcessToken =
-      flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === Runtime.Types.ProcessTokenType.onSuspend;
-      });
 
     const flowNodeIsMessageStartEvent: boolean = this.startEvent.messageEventDefinition !== undefined;
     const flowNodeIsSignalStartEvent: boolean = this.startEvent.signalEventDefinition !== undefined;

--- a/src/runtime/engine/flow_node_handler/start_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/start_event_handler.ts
@@ -67,7 +67,7 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
       case Runtime.Types.FlowNodeInstanceState.suspended:
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
-        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
+        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
@@ -94,24 +94,11 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
     }
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onSuspended" state.
-   *
-   * When the FlowNodeInstance was interrupted during this stage, we need to
-   * run the handler again, except for the "onSuspend" state change.
-   *
-   * @async
-   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
-   *                             suspended.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                     ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     const flowNodeIsMessageStartEvent: boolean = this.startEvent.messageEventDefinition !== undefined;
     const flowNodeIsSignalStartEvent: boolean = this.startEvent.signalEventDefinition !== undefined;
@@ -133,23 +120,10 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
     return new NextFlowNodeInfo(nextFlowNode, onSuspendToken, processTokenFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onResumed" state.
-   *
-   * Basically, the StartEvent was already finished.
-   * The final result is only missing in the database.
-   *
-   * @async
-   * @param   resumeToken   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                     processTokenFacade: IProcessTokenFacade,
-                                     processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.startEvent.id, resumeToken.payload);
     await this.persistOnExit(resumeToken);

--- a/src/runtime/engine/flow_node_handler/start_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/start_event_handler.ts
@@ -65,7 +65,6 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
@@ -81,11 +80,9 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.startEvent.id, onExitToken);
 
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -177,12 +174,33 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
                                     ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.startEvent.id, resumeToken.payload);
-
-    const nextNodeAfter: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.startEvent);
-
     await this.persistOnExit(resumeToken);
 
-    return new NextFlowNodeInfo(nextNodeAfter, resumeToken, processTokenFacade);
+    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
+  }
+
+  /**
+   * Resumes the given FlowNodeInstance from the point where it assumed the
+   * "onExit" state.
+   *
+   * Basically, the handler had already finished.
+   * We just need to return the info about the next FlowNode to run.
+   *
+   * @async
+   * @param   resumeToken        The ProcessToken stored after resuming the
+   *                             FlowNodeInstance.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade,
+                                    ): Promise<NextFlowNodeInfo> {
+
+    processTokenFacade.addResultForFlowNode(this.startEvent.id, onExitToken.payload);
+
+    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
   }
 
   private async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/start_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/start_event_handler.ts
@@ -55,58 +55,6 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
     return this._executeHandler(token, processTokenFacade, processModelFacade);
   }
 
-  protected async resumeInternally(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                   identity: IIdentity,
-                                 ): Promise<NextFlowNodeInfo> {
-
-    this.logger.verbose(`Resuming FlowNodeInstance ${flowNodeInstance.id}.`);
-
-    switch (flowNodeInstance.state) {
-      case Runtime.Types.FlowNodeInstanceState.suspended:
-        this.logger.verbose(`FlowNodeInstance was left suspended. Waiting for the StartEvents trigger event to occur.`);
-        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
-
-        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.running:
-
-        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
-
-        const startEventConditionNotYetAchieved: boolean = resumeToken === undefined;
-
-        if (startEventConditionNotYetAchieved) {
-          this.logger.verbose(`FlowNodeInstance was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
-
-          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
-        }
-
-        this.logger.verbose(`The trigger event as already occured and the handler was resumed. Finishing up the handler.`);
-
-        return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`FlowNodeInstance was already finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
-
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                     flowNodeInstance.error);
-        throw flowNodeInstance.error;
-
-      case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it was terminated!`;
-        this.logger.error(terminatedError);
-        throw new InternalServerError(terminatedError);
-
-      default:
-        const invalidStateError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because its state cannot be determined!`;
-        this.logger.error(invalidStateError);
-        throw new InternalServerError(invalidStateError);
-    }
-  }
-
   protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
                                         onSuspendToken: Runtime.Types.ProcessToken,
                                         processTokenFacade: IProcessTokenFacade,

--- a/src/runtime/engine/flow_node_handler/start_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/start_event_handler.ts
@@ -57,32 +57,26 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
                                    identity: IIdentity,
                                  ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
+        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const startEventConditionNotYetAchieved: boolean = resumeToken === undefined;
 
         if (startEventConditionNotYetAchieved) {
-          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/start_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/start_event_handler.ts
@@ -89,7 +89,7 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new Error(`Cannot resume StartEvent instance ${flowNodeInstance.id}, because it was terminated!`);
+        throw new InternalServerError(`Cannot resume StartEvent instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume StartEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/start_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/start_event_handler.ts
@@ -120,17 +120,6 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
     return new NextFlowNodeInfo(nextFlowNode, onSuspendToken, processTokenFacade);
   }
 
-  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                       processTokenFacade: IProcessTokenFacade,
-                                       processModelFacade: IProcessModelFacade,
-                                      ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.startEvent.id, resumeToken.payload);
-    await this.persistOnExit(resumeToken);
-
-    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
-  }
-
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {

--- a/src/runtime/engine/flow_node_handler/start_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/start_event_handler.ts
@@ -75,7 +75,9 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
         const startEventConditionNotYetAchieved: boolean = resumeToken === undefined;
 
         if (startEventConditionNotYetAchieved) {
-          return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
+          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+
+          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
@@ -90,30 +92,6 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
       default:
         throw new InternalServerError(`Cannot resume StartEvent instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }
-  }
-
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onEnter" state.
-   *
-   * Basically, the handler was not yet executed, except for the initial
-   * state change.
-   *
-   * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterEnter(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                    processTokenFacade: IProcessTokenFacade,
-                                    processModelFacade: IProcessModelFacade,
-                                   ): Promise<NextFlowNodeInfo> {
-
-    // When the FNI was interrupted directly after the onEnter state change, only one token will be present.
-    const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
-
-    return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);
   }
 
   /**
@@ -179,33 +157,9 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
     return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onExit" state.
-   *
-   * Basically, the handler had already finished.
-   * We just need to return the info about the next FlowNode to run.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.startEvent.id, onExitToken.payload);
-
-    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
-  }
-
-  private async _executeHandler(token: Runtime.Types.ProcessToken,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
     this._sendProcessStartedMessage(token, this.startEvent.id);
 

--- a/src/runtime/engine/flow_node_handler/start_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/start_event_handler.ts
@@ -104,20 +104,30 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
     const flowNodeIsSignalStartEvent: boolean = this.startEvent.signalEventDefinition !== undefined;
     const flowNodeIsTimerStartEvent: boolean = this.startEvent.timerEventDefinition !== undefined;
 
+    const isSpecializedStartEvent: boolean = flowNodeIsMessageStartEvent || flowNodeIsSignalStartEvent || flowNodeIsTimerStartEvent;
+
     // If the StartEvent is not a regular StartEvent,
     // wait for the defined condition to be fulfilled.
-    if (flowNodeIsMessageStartEvent) {
-      await this._waitForMessage(onSuspendToken, this.startEvent.messageEventDefinition.name);
-    } else if (flowNodeIsSignalStartEvent) {
-      await this._waitForSignal(onSuspendToken, this.startEvent.signalEventDefinition.name);
-    } else if (flowNodeIsTimerStartEvent) {
-      await this._waitForTimerToElapse(onSuspendToken, this.startEvent.timerEventDefinition);
+    if (isSpecializedStartEvent) {
+
+      let newTokenPayload: any =
+        await new Promise<any>(async(resolve: Function, reject: Function): Promise<void> => {
+          if (flowNodeIsMessageStartEvent) {
+            newTokenPayload = this._waitForMessage(onSuspendToken, resolve);
+          } else if (flowNodeIsSignalStartEvent) {
+            newTokenPayload = this._waitForSignal(onSuspendToken, resolve);
+          } else if (flowNodeIsTimerStartEvent) {
+            newTokenPayload = this._waitForTimerToElapse(onSuspendToken, resolve);
+          }
+        });
+
+      onSuspendToken.payload = newTokenPayload;
+      await this.persistOnResume(onSuspendToken);
     }
 
-    const nextFlowNode: Model.Base.FlowNode = await processModelFacade.getNextFlowNodeFor(this.startEvent);
     await this.persistOnExit(onSuspendToken);
 
-    return new NextFlowNodeInfo(nextFlowNode, onSuspendToken, processTokenFacade);
+    return this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
@@ -130,24 +140,29 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
     const flowNodeIsSignalStartEvent: boolean = this.startEvent.signalEventDefinition !== undefined;
     const flowNodeIsTimerStartEvent: boolean = this.startEvent.timerEventDefinition !== undefined;
 
+    const isSpecializedStartEvent: boolean = flowNodeIsMessageStartEvent || flowNodeIsSignalStartEvent || flowNodeIsTimerStartEvent;
+
     // If the StartEvent is not a regular StartEvent,
     // wait for the defined condition to be fulfilled.
-    if (flowNodeIsMessageStartEvent) {
-      await this.persistOnSuspend(token);
-      await this._waitForMessage(token, this.startEvent.messageEventDefinition.name);
-    } else if (flowNodeIsSignalStartEvent) {
-      await this.persistOnSuspend(token);
-      await this._waitForSignal(token, this.startEvent.signalEventDefinition.name);
-    } else if (flowNodeIsTimerStartEvent) {
-      await this.persistOnSuspend(token);
-      await this._waitForTimerToElapse(token, this.startEvent.timerEventDefinition);
-    }
+    if (isSpecializedStartEvent) {
 
-    const nextFlowNode: Model.Base.FlowNode = await processModelFacade.getNextFlowNodeFor(this.startEvent);
+      let newTokenPayload: any = token.payload;
+
+      if (flowNodeIsMessageStartEvent) {
+        newTokenPayload = await this._suspendAndWaitForMessage(token);
+      } else if (flowNodeIsSignalStartEvent) {
+        newTokenPayload = await this._suspendAndWaitForSignal(token);
+      } else if (flowNodeIsTimerStartEvent) {
+        newTokenPayload = await this._suspendAndWaitForTimerToElapse(token);
+      }
+
+      token.payload = newTokenPayload;
+      await this.persistOnResume(token);
+    }
 
     await this.persistOnExit(token);
 
-    return new NextFlowNodeInfo(nextFlowNode, token, processTokenFacade);
+    return this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
   }
 
   /**
@@ -173,99 +188,115 @@ export class StartEventHandler extends FlowNodeHandler<Model.Events.StartEvent> 
 
     this._eventAggregator.publish(processWithIdStartedMessage, processStartedMessage);
   }
-  /**
-   * Creates a subscription on the EventAggregator and waits to receive the
-   * designated message.
-   *
-   * @async
-   * @param token       The current ProcessToken.
-   * @param messageName The message to wait for.
-   */
-  private async _waitForMessage(token: Runtime.Types.ProcessToken, messageName: string): Promise<void> {
 
-    return new Promise<void>((async(resolve: Function): Promise<void> => {
+  private async _suspendAndWaitForMessage(currentToken: Runtime.Types.ProcessToken): Promise<any> {
+    return new Promise<any>(async(resolve: Function, reject: Function): Promise<void> => {
+      this._waitForMessage(currentToken, resolve);
+      await this.persistOnSuspend(currentToken);
+    });
+  }
 
-      const messageEventName: string = eventAggregatorSettings.routePaths.messageEventReached
-        .replace(eventAggregatorSettings.routeParams.messageReference, messageName);
+  private async _suspendAndWaitForSignal(currentToken: Runtime.Types.ProcessToken): Promise<any> {
+    return new Promise<any>(async(resolve: Function, reject: Function): Promise<void> => {
+      this._waitForSignal(currentToken, resolve);
+      await this.persistOnSuspend(currentToken);
+    });
+  }
 
-      const subscription: ISubscription = this._eventAggregator.subscribeOnce(messageEventName, async(message: MessageEventReachedMessage) => {
-
-        if (subscription) {
-          subscription.dispose();
-        }
-
-        await this.persistOnResume(token);
-
-        resolve();
-      });
-
-      await this.persistOnSuspend(token);
-    }));
+  private async _suspendAndWaitForTimerToElapse(currentToken: Runtime.Types.ProcessToken): Promise<any> {
+    return new Promise<any>(async(resolve: Function, reject: Function): Promise<void> => {
+      this._waitForTimerToElapse(currentToken, resolve);
+      await this.persistOnSuspend(currentToken);
+    });
   }
 
   /**
    * Creates a subscription on the EventAggregator and waits to receive the
-   * designated signal.
+   * message described in the StartEvents event definition.
    *
-   * @async
-   * @param token      The current ProcessToken.
-   * @param signalName The signal to wait for.
+   * @param currentToken The current ProcessToken.
+   * @param resolveFunc  The function to call after the message was received.
    */
-  private async _waitForSignal(token: Runtime.Types.ProcessToken, signalName: string): Promise<void> {
+  private _waitForMessage(currentToken: Runtime.Types.ProcessToken, resolveFunc: Function): void {
 
-    return new Promise<void>(async(resolve: Function): Promise<void> => {
+    const messageDefinitionName: string = this.startEvent.messageEventDefinition.name;
 
-      const signalEventName: string = eventAggregatorSettings.routePaths.signalEventReached
-        .replace(eventAggregatorSettings.routeParams.signalReference, signalName);
+    const messageEventName: string = eventAggregatorSettings.routePaths.messageEventReached
+      .replace(eventAggregatorSettings.routeParams.messageReference, messageDefinitionName);
 
-      const subscription: ISubscription = this._eventAggregator.subscribeOnce(signalEventName, async(message: SignalEventReachedMessage) => {
+    const subscription: ISubscription =
+      this._eventAggregator.subscribeOnce(messageEventName, async(message: MessageEventReachedMessage) => {
 
         if (subscription) {
           subscription.dispose();
         }
 
-        await this.persistOnResume(token);
+        const messageHasPayload: boolean = message && message.currentToken;
+        const tokenToReturn: any = messageHasPayload
+          ? message.currentToken
+          : currentToken.payload;
 
-        resolve();
+        resolveFunc(tokenToReturn);
       });
+  }
 
-      await this.persistOnSuspend(token);
-    });
+  /**
+   * Creates a subscription on the EventAggregator and waits to receive the
+   * signal described in the StartEvents event definition.
+   *
+   * @param currentToken The current ProcessToken.
+   * @param resolveFunc  The function to call after the signal was received.
+   */
+  private _waitForSignal(currentToken: Runtime.Types.ProcessToken, resolveFunc: Function): void {
+
+    const signalDefinitionName: string = this.startEvent.signalEventDefinition.name;
+
+    const signalEventName: string = eventAggregatorSettings.routePaths.signalEventReached
+      .replace(eventAggregatorSettings.routeParams.signalReference, signalDefinitionName);
+
+    const subscription: ISubscription =
+      this._eventAggregator.subscribeOnce(signalEventName, async(signal: SignalEventReachedMessage) => {
+
+        if (subscription) {
+          subscription.dispose();
+        }
+
+        const signalHasPayload: boolean = signal && signal.currentToken;
+        const tokenToReturn: any = signalHasPayload
+          ? signal.currentToken
+          : currentToken.payload;
+
+        resolveFunc(tokenToReturn);
+      });
   }
 
   /**
    * If a timed StartEvent is used, this will delay the events execution
    * until the timer has elapsed.
    *
-   * @async
-   * @param token           The current ProcessToken.
-   * @param timerDefinition The definition that contains the timer to use.
+   * @param currentToken The current ProcessToken.
+   * @param resolveFunc  The function to call after the timer has elapsed.
    */
-  private async _waitForTimerToElapse(token: Runtime.Types.ProcessToken,
-                                      timerDefinition: Model.EventDefinitions.TimerEventDefinition): Promise<void> {
+  private _waitForTimerToElapse(currentToken: Runtime.Types.ProcessToken, resolveFunc: Function): void {
 
-    return new Promise<void> (async(resolve: Function, reject: Function): Promise<void> => {
+    const timerDefinition: Model.EventDefinitions.TimerEventDefinition = this.startEvent.timerEventDefinition;
 
-      let timerSubscription: ISubscription;
+    let timerSubscription: ISubscription;
 
-      const timerType: TimerDefinitionType = this._timerFacade.parseTimerDefinitionType(timerDefinition);
-      const timerValue: string = this._timerFacade.parseTimerDefinitionValue(timerDefinition);
+    const timerType: TimerDefinitionType = this._timerFacade.parseTimerDefinitionType(timerDefinition);
+    const timerValue: string = this._timerFacade.parseTimerDefinitionValue(timerDefinition);
 
-      const timerElapsed: any = async(): Promise<void> => {
+    const timerElapsed: any = (): void => {
 
-        await this.persistOnResume(token);
+      const cancelSubscription: boolean = timerSubscription && timerType !== TimerDefinitionType.cycle;
 
-        const cancelSubscription: boolean = timerSubscription && timerType !== TimerDefinitionType.cycle;
+      if (cancelSubscription) {
+        timerSubscription.dispose();
+      }
 
-        if (cancelSubscription) {
-          timerSubscription.dispose();
-        }
+      resolveFunc(currentToken.payload);
+    };
 
-        resolve();
-      };
-
-      timerSubscription = this._timerFacade.initializeTimer(this.startEvent, timerType, timerValue, timerElapsed);
-      await this.persistOnSuspend(token);
-    });
+    timerSubscription = this._timerFacade.initializeTimer(this.startEvent, timerType, timerValue, timerElapsed);
   }
 }

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -25,8 +25,6 @@ import {FlowNodeHandler} from './index';
 
 export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProcess> {
 
-  private logger: Logger;
-
   private _eventAggregator: IEventAggregator;
   private _flowNodeHandlerFactory: IFlowNodeHandlerFactory;
   private _processTerminatedMessage: TerminateEndEventReachedMessage;
@@ -69,7 +67,7 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        this.logger.verbose(`SubProcess ${flowNodeInstance.id} was left suspended. Waiting for the Message to be received.`);
+        this.logger.verbose(`FlowNodeInstance ${flowNodeInstance.id} was left suspended. Waiting for the Message to be received.`);
         const onSuspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, onSuspendToken, processTokenFacade, processModelFacade, identity);
@@ -79,35 +77,34 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
 
         const subProcessNotYetExecuted: boolean = resumeToken === undefined;
         if (subProcessNotYetExecuted) {
-          this.logger.verbose(`SubProcess ${flowNodeInstance.id} was interrupted at the beginning. Resuming from the start.`);
+          this.logger.verbose(`FlowNodeInstance ${flowNodeInstance.id} was interrupted at the beginning. Resuming from the start.`);
           const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
         }
 
-        this.logger.verbose(`SubProcess ${flowNodeInstance.id} was already finished. Finishing up the handler.`);
+        this.logger.verbose(`FlowNodeInstance ${flowNodeInstance.id} was already finished. Finishing up the handler.`);
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
 
       case Runtime.Types.FlowNodeInstanceState.finished:
-        this.logger.verbose(`SubProcess was finished. Skipping ahead.`);
+        this.logger.verbose(`FlowNodeInstance was already finished. Skipping ahead.`);
         const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade, identity);
 
       case Runtime.Types.FlowNodeInstanceState.error:
-        this.logger.error(`Cannot resume SubProcess instance ${flowNodeInstance.id}, because it previously exited with an error!`,
-                      flowNodeInstance.error);
+        this.logger.error(`Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it previously exited with an error!`,
+                     flowNodeInstance.error);
         throw flowNodeInstance.error;
 
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        const terminatedError: string = `Cannot resume SubProcess instance ${flowNodeInstance.id}, because it was terminated!`;
+        const terminatedError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it was terminated!`;
         this.logger.error(terminatedError);
         throw new InternalServerError(terminatedError);
 
       default:
-        const invalidStateError: string =
-          `Cannot resume SubProcess instance ${flowNodeInstance.id}, because its state cannot be determined!`;
+        const invalidStateError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because its state cannot be determined!`;
         this.logger.error(invalidStateError);
         throw new InternalServerError(invalidStateError);
     }

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -25,15 +25,13 @@ import {FlowNodeHandler} from './index';
 
 export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProcess> {
 
-  private _correlationService: ICorrelationService;
   private _eventAggregator: IEventAggregator;
   private _flowNodeHandlerFactory: IFlowNodeHandlerFactory;
   private _resumeProcessService: IResumeProcessService;
 
   private _processTerminatedMessage: TerminateEndEventReachedMessage;
 
-  constructor(correlationService: ICorrelationService,
-              eventAggregator: IEventAggregator,
+  constructor(eventAggregator: IEventAggregator,
               flowNodeHandlerFactory: IFlowNodeHandlerFactory,
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
@@ -42,7 +40,6 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
               subProcessModel: Model.Activities.SubProcess) {
     super(flowNodeInstanceService, loggingApiService, metricsService, subProcessModel);
 
-    this._correlationService = correlationService;
     this._eventAggregator = eventAggregator;
     this._flowNodeHandlerFactory = flowNodeHandlerFactory;
     this._resumeProcessService = resumeProcessService;

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -123,22 +123,21 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
         return entry.processModelId === this.subProcess.id;
       });
 
-    let callActivityResult: any;
+    let subProcessResult: any;
 
-    const callActivityNotYetExecuted: boolean = matchingSubProcess === undefined;
-    if (callActivityNotYetExecuted) {
+    const subProcessNotYetExecuted: boolean = matchingSubProcess === undefined;
+    if (subProcessNotYetExecuted) {
       // Subprocess not yet started. We need to run the handler again.
-      const subProcessResult: any = await this._executeSubprocess(onSuspendToken, processTokenFacade, processModelFacade, identity);
-      callActivityResult = subProcessResult;
+      subProcessResult = await this._executeSubprocess(onSuspendToken, processTokenFacade, processModelFacade, identity);
     } else {
       // Subprocess was already started. Resume it and wait for the result:
-      callActivityResult =
+      subProcessResult =
         await this._resumeProcessService.resumeProcessInstanceById(identity, matchingSubProcess.processModelId, matchingSubProcess.processInstanceId);
     }
 
-    onSuspendToken.payload = callActivityResult;
+    onSuspendToken.payload = subProcessResult;
     await this.persistOnResume(onSuspendToken);
-    await processTokenFacade.addResultForFlowNode(this.subProcess.id, callActivityResult);
+    await processTokenFacade.addResultForFlowNode(this.subProcess.id, subProcessResult);
     await this.persistOnExit(onSuspendToken);
 
     return this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -194,16 +194,15 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
 
     const subProcessInstanceId: string = uuid.v4();
 
-    const initialTokenData: any = await processTokenFacade.getOldTokenFormat();
     const currentResults: any = await processTokenFacade.getAllResults();
 
     const subProcessTokenFacade: IProcessTokenFacade =
       new ProcessTokenFacade(subProcessInstanceId, this.subProcess.id, currentProcessToken.correlationId, identity);
 
     subProcessTokenFacade.importResults(currentResults);
-    subProcessTokenFacade.addResultForFlowNode(subProcessStartEvent.id, initialTokenData.current);
+    subProcessTokenFacade.addResultForFlowNode(subProcessStartEvent.id, currentProcessToken.payload);
 
-    const subProcessToken: Runtime.Types.ProcessToken = subProcessTokenFacade.createProcessToken(initialTokenData.current);
+    const subProcessToken: Runtime.Types.ProcessToken = subProcessTokenFacade.createProcessToken(currentProcessToken.payload);
     subProcessToken.caller = currentProcessToken.processInstanceId;
 
     await this._executeSubProcessFlowNode(subProcessStartEvent,
@@ -267,7 +266,6 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
     const subProcessStartEvents: Array<Model.Events.StartEvent> = subProcessModelFacade.getStartEvents();
     const subProcessStartEvent: Model.Events.StartEvent = subProcessStartEvents[0];
 
-    const initialTokenData: any = await processTokenFacade.getOldTokenFormat();
     const currentResults: any = await processTokenFacade.getAllResults();
 
     const subProcessInstanceId: string = flowNodeInstancesForSubprocess[0].processInstanceId;
@@ -276,9 +274,9 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
       new ProcessTokenFacade(subProcessInstanceId, this.subProcess.id, currentProcessToken.correlationId, identity);
 
     subProcessTokenFacade.importResults(currentResults);
-    subProcessTokenFacade.addResultForFlowNode(subProcessStartEvent.id, initialTokenData.current);
+    subProcessTokenFacade.addResultForFlowNode(subProcessStartEvent.id, currentProcessToken.payload);
 
-    const subProcessToken: Runtime.Types.ProcessToken = subProcessTokenFacade.createProcessToken(initialTokenData.current);
+    const subProcessToken: Runtime.Types.ProcessToken = subProcessTokenFacade.createProcessToken(currentProcessToken.payload);
 
     const flowNodeInstanceForStartEvent: Runtime.Types.FlowNodeInstance =
       flowNodeInstancesForSubprocess.find((entry: Runtime.Types.FlowNodeInstance): boolean => {

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -132,7 +132,8 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
       callActivityResult = subProcessResult;
     } else {
       // Subprocess was already started. Resume it and wait for the result:
-      callActivityResult = await this._resumeProcessService.resumeProcessInstanceById(matchingSubProcess.processInstanceId);
+      callActivityResult =
+        await this._resumeProcessService.resumeProcessInstanceById(identity, matchingSubProcess.processModelId, matchingSubProcess.processInstanceId);
     }
 
     onSuspendToken.payload = callActivityResult;

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -110,17 +110,6 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
     throw new Error('Not implemented yet.');
   }
 
-  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                       processTokenFacade: IProcessTokenFacade,
-                                       processModelFacade: IProcessModelFacade,
-                                      ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.subProcess.id, resumeToken.payload);
-    await this.persistOnExit(resumeToken);
-
-    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
-  }
-
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade,

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -1,3 +1,4 @@
+import {Logger} from 'loggerhythm';
 import * as uuid from 'uuid';
 
 import {InternalServerError} from '@essential-projects/errors_ts';
@@ -8,13 +9,11 @@ import {ILoggingApi} from '@process-engine/logging_api_contracts';
 import {IMetricsApi} from '@process-engine/metrics_api_contracts';
 import {
   eventAggregatorSettings,
-  ICorrelationService,
   IFlowNodeHandler,
   IFlowNodeHandlerFactory,
   IFlowNodeInstanceService,
   IProcessModelFacade,
   IProcessTokenFacade,
-  IResumeProcessService,
   Model,
   NextFlowNodeInfo,
   Runtime,
@@ -26,27 +25,23 @@ import {FlowNodeHandler} from './index';
 
 export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProcess> {
 
-  private _correlationService: ICorrelationService;
+  private logger: Logger;
+
   private _eventAggregator: IEventAggregator;
   private _flowNodeHandlerFactory: IFlowNodeHandlerFactory;
-  private _resumeProcessService: IResumeProcessService;
-
   private _processTerminatedMessage: TerminateEndEventReachedMessage;
 
-  constructor(correlationService: ICorrelationService,
-              eventAggregator: IEventAggregator,
+  constructor(eventAggregator: IEventAggregator,
               flowNodeHandlerFactory: IFlowNodeHandlerFactory,
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
-              resumeProcessService: IResumeProcessService,
               subProcessModel: Model.Activities.SubProcess) {
     super(flowNodeInstanceService, loggingApiService, metricsService, subProcessModel);
 
-    this._correlationService = correlationService;
     this._eventAggregator = eventAggregator;
     this._flowNodeHandlerFactory = flowNodeHandlerFactory;
-    this._resumeProcessService = resumeProcessService;
+    this.logger = Logger.createLogger(`processengine:sub_process_handler:${subProcessModel.id}`);
   }
 
   private get subProcess(): Model.Activities.SubProcess {
@@ -58,6 +53,7 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
+    this.logger.verbose(`Executing SubProcess instance ${this.flowNodeInstanceId}.`);
     await this.persistOnEnter(token);
 
     return this._executeHandler(token, processTokenFacade, processModelFacade, identity);
@@ -69,6 +65,8 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
                                 identity: IIdentity,
                               ): Promise<NextFlowNodeInfo> {
 
+    this.logger.verbose(`Resuming SubProcess instance ${this.flowNodeInstanceId}.`);
+
     function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
       return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
         return token.type === tokenType;
@@ -77,6 +75,7 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
+        this.logger.verbose(`SubProcess ${flowNodeInstance.id} was left suspended. Waiting for the Message to be received.`);
         const onSuspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, onSuspendToken, processTokenFacade, processModelFacade, identity);
@@ -86,22 +85,37 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
 
         const subProcessNotYetExecuted: boolean = resumeToken === undefined;
         if (subProcessNotYetExecuted) {
+          this.logger.verbose(`SubProcess ${flowNodeInstance.id} was interrupted at the beginning. Resuming from the start.`);
           const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
         }
 
+        this.logger.verbose(`SubProcess ${flowNodeInstance.id} was already finished. Finishing up the handler.`);
+
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
+
       case Runtime.Types.FlowNodeInstanceState.finished:
+        this.logger.verbose(`SubProcess was finished. Skipping ahead.`);
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade, identity);
+
       case Runtime.Types.FlowNodeInstanceState.error:
+        this.logger.error(`Cannot resume SubProcess instance ${flowNodeInstance.id}, because it previously exited with an error!`,
+                      flowNodeInstance.error);
         throw flowNodeInstance.error;
+
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new InternalServerError(`Cannot resume SubProcess instance ${flowNodeInstance.id}, because it was terminated!`);
+        const terminatedError: string = `Cannot resume SubProcess instance ${flowNodeInstance.id}, because it was terminated!`;
+        this.logger.error(terminatedError);
+        throw new InternalServerError(terminatedError);
+
       default:
-        throw new InternalServerError(`Cannot resume SubProcess instance ${flowNodeInstance.id}, because its state cannot be determined!`);
+        const invalidStateError: string =
+          `Cannot resume SubProcess instance ${flowNodeInstance.id}, because its state cannot be determined!`;
+        this.logger.error(invalidStateError);
+        throw new InternalServerError(invalidStateError);
     }
   }
 
@@ -112,32 +126,30 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
                                         identity: IIdentity,
                                        ): Promise<NextFlowNodeInfo> {
 
-    this._subscribeToProcessTerminatedEvent(flowNodeInstance.processInstanceId);
+    this._subscribeToProcessTerminatedEvent(onSuspendToken.processInstanceId);
 
-    // First we need to find out if the Subprocess was already started.
-    const correlation: Runtime.Types.Correlation
-      = await this._correlationService.getSubprocessesForProcessInstance(flowNodeInstance.processInstanceId);
+    // TODO: This can probably be removed, when we have refactored the way we handle ParallelGateways in general.
+    // For now, we need that data here for use in the parallel branches.
+    // ----
+    const flowNodeInstancesForProcessModel: Array<Runtime.Types.FlowNodeInstance> =
+      await this.flowNodeInstanceService.queryByProcessModel(this.subProcess.id);
 
-    const matchingSubProcess: Runtime.Types.CorrelationProcessModel =
-      correlation.processModels.find((entry: Runtime.Types.CorrelationProcessModel): boolean => {
-        return entry.processModelId === this.subProcess.id;
+    const flowNodeInstancesForSubProcess: Array<Runtime.Types.FlowNodeInstance> =
+      flowNodeInstancesForProcessModel.filter((entry: Runtime.Types.FlowNodeInstance): boolean => {
+        // TODO: Can be simplified, as soon as the DataModels for FlowNodeInstance and ProcessToken have been refactored.
+        return entry.tokens[0].caller === onSuspendToken.processInstanceId;
       });
+    // ----
 
-    let subProcessResult: any;
-
-    const subProcessNotYetExecuted: boolean = matchingSubProcess === undefined;
-    if (subProcessNotYetExecuted) {
-      // Subprocess not yet started. We need to run the handler again.
-      subProcessResult = await this._executeSubprocess(onSuspendToken, processTokenFacade, processModelFacade, identity);
-    } else {
-      // Subprocess was already started. Resume it and wait for the result:
-      subProcessResult =
-        await this._resumeProcessService.resumeProcessInstanceById(identity, matchingSubProcess.processModelId, matchingSubProcess.processInstanceId);
-    }
+    const subProcessWasNotStarted: boolean = flowNodeInstancesForSubProcess.length === 0;
+    const subProcessResult: any = subProcessWasNotStarted
+      ? await this._executeSubprocess(onSuspendToken, processTokenFacade, processModelFacade, identity)
+      : await this._resumeSubProcess(flowNodeInstancesForSubProcess, onSuspendToken, processTokenFacade, processModelFacade, identity);
 
     onSuspendToken.payload = subProcessResult;
     await this.persistOnResume(onSuspendToken);
-    await processTokenFacade.addResultForFlowNode(this.subProcess.id, subProcessResult);
+
+    processTokenFacade.addResultForFlowNode(this.subProcess.id, subProcessResult);
     await this.persistOnExit(onSuspendToken);
 
     return this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);
@@ -203,14 +215,6 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
     const subProcessToken: Runtime.Types.ProcessToken = subProcessTokenFacade.createProcessToken(initialTokenData.current);
     subProcessToken.caller = currentProcessToken.processInstanceId;
 
-    // Not that Subprocesses do not have XML of their own.
-    await this._correlationService.createEntry(identity,
-                                               currentProcessToken.correlationId,
-                                               subProcessInstanceId,
-                                               this.subProcess.id,
-                                               '',
-                                               currentProcessToken.processInstanceId);
-
     await this._executeSubProcessFlowNode(subProcessStartEvent,
                                           subProcessToken,
                                           subProcessTokenFacade,
@@ -258,5 +262,109 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
                                   identity,
                                   currentFlowNodeInstanceId);
     }
+  }
+
+  private async _resumeSubProcess(flowNodeInstancesForSubprocess: Array<Runtime.Types.FlowNodeInstance>,
+                                  currentProcessToken: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade,
+                                  identity: IIdentity,
+                                 ): Promise<any> {
+
+    const subProcessModelFacade: IProcessModelFacade = processModelFacade.getSubProcessModelFacade(this.subProcess);
+
+    const subProcessStartEvents: Array<Model.Events.StartEvent> = subProcessModelFacade.getStartEvents();
+    const subProcessStartEvent: Model.Events.StartEvent = subProcessStartEvents[0];
+
+    const initialTokenData: any = await processTokenFacade.getOldTokenFormat();
+    const currentResults: any = await processTokenFacade.getAllResults();
+
+    const subProcessInstanceId: string = flowNodeInstancesForSubprocess[0].processInstanceId;
+
+    const subProcessTokenFacade: IProcessTokenFacade =
+      new ProcessTokenFacade(subProcessInstanceId, this.subProcess.id, currentProcessToken.correlationId, identity);
+
+    subProcessTokenFacade.importResults(currentResults);
+    subProcessTokenFacade.addResultForFlowNode(subProcessStartEvent.id, initialTokenData.current);
+
+    const subProcessToken: Runtime.Types.ProcessToken = subProcessTokenFacade.createProcessToken(initialTokenData.current);
+
+    const flowNodeInstanceForStartEvent: Runtime.Types.FlowNodeInstance =
+      flowNodeInstancesForSubprocess.find((entry: Runtime.Types.FlowNodeInstance): boolean => {
+        return entry.flowNodeId === subProcessStartEvent.id;
+      });
+
+    await this._resumeSubProcessFlowNode(subProcessStartEvent,
+                                         flowNodeInstanceForStartEvent,
+                                         subProcessToken,
+                                         subProcessTokenFacade,
+                                         subProcessModelFacade,
+                                         identity,
+                                         flowNodeInstancesForSubprocess);
+
+    // After all FlowNodes in the SubProcess have been executed, set the last "current" token value as a result of the whole SubProcess
+    // and on the original ProcessTokenFacade, so that is is accessible by the original Process
+    const subProcessTokenData: any = await subProcessTokenFacade.getOldTokenFormat();
+    const subProcessResult: any = subProcessTokenData.current || {};
+
+    return subProcessResult;
+  }
+
+  private async _resumeSubProcessFlowNode(flowNodeToResume: Model.Base.FlowNode,
+                                          flowNodeInstanceForFlowNode: Runtime.Types.FlowNodeInstance,
+                                          token: Runtime.Types.ProcessToken,
+                                          processTokenFacade: IProcessTokenFacade,
+                                          processModelFacade: IProcessModelFacade,
+                                          identity: IIdentity,
+                                          flowNodeInstancesForProcessInstance: Array<Runtime.Types.FlowNodeInstance>,
+                                          ): Promise<NextFlowNodeInfo> {
+
+    const flowNodeHandler: IFlowNodeHandler<Model.Base.FlowNode> = await this._flowNodeHandlerFactory.create(flowNodeToResume, processModelFacade);
+
+    const nextFlowNodeInfo: NextFlowNodeInfo =
+      await flowNodeHandler.resume(flowNodeInstanceForFlowNode, processTokenFacade, processModelFacade, identity);
+
+    const processWasTerminated: boolean = this._processTerminatedMessage !== undefined;
+    if (processWasTerminated) {
+      await this.flowNodeInstanceService.persistOnTerminate(flowNodeToResume, flowNodeInstanceForFlowNode.id, token);
+      throw new InternalServerError(`Process was terminated through TerminateEndEvent "${this._processTerminatedMessage.flowNodeId}".`);
+    }
+
+    const subProcessHasAnotherFlowNodeToExecute: boolean = nextFlowNodeInfo.flowNode !== undefined;
+    if (!subProcessHasAnotherFlowNodeToExecute) {
+      return;
+    }
+
+    // Check if a FlowNodeInstance for the next FlowNode has already been persisted
+    // during a previous execution of the ProcessInstance.
+    const flowNodeInstanceForNextFlowNode: Runtime.Types.FlowNodeInstance =
+      flowNodeInstancesForProcessInstance.find((entry: Runtime.Types.FlowNodeInstance): boolean => {
+        return entry.flowNodeId === nextFlowNodeInfo.flowNode.id;
+      });
+
+    const resumingNotFinished: boolean = flowNodeInstanceForNextFlowNode !== undefined;
+    if (resumingNotFinished) {
+      this.logger.info(`Resuming FlowNode ${flowNodeInstanceForNextFlowNode.flowNodeId} for SubProcess instance ${this.flowNodeInstanceId}.`);
+      // If a matching FlowNodeInstance exists, continue resuming.
+      await this._resumeSubProcessFlowNode(nextFlowNodeInfo.flowNode,
+                                           flowNodeInstanceForNextFlowNode,
+                                           nextFlowNodeInfo.token,
+                                           nextFlowNodeInfo.processTokenFacade,
+                                           processModelFacade,
+                                           identity,
+                                           flowNodeInstancesForProcessInstance);
+    } else {
+      // Otherwise, we will have arrived at the point at which the branch was previously interrupted,
+      // and we can continue with normal execution.
+      this.logger.info(`All interrupted FlowNodeInstances resumed and finished.`);
+      this.logger.info(`Continuing SubProcess normally.`);
+      await this._executeSubProcessFlowNode(nextFlowNodeInfo.flowNode,
+                                            nextFlowNodeInfo.token,
+                                            nextFlowNodeInfo.processTokenFacade,
+                                            processModelFacade,
+                                            identity,
+                                            flowNodeInstanceForFlowNode.id);
+    }
+
   }
 }

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -67,26 +67,20 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
 
     this.logger.verbose(`Resuming SubProcess instance ${this.flowNodeInstanceId}.`);
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
         this.logger.verbose(`SubProcess ${flowNodeInstance.id} was left suspended. Waiting for the Message to be received.`);
-        const onSuspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+        const onSuspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, onSuspendToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
+        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const subProcessNotYetExecuted: boolean = resumeToken === undefined;
         if (subProcessNotYetExecuted) {
           this.logger.verbose(`SubProcess ${flowNodeInstance.id} was interrupted at the beginning. Resuming from the start.`);
-          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);
         }
@@ -97,7 +91,7 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
 
       case Runtime.Types.FlowNodeInstanceState.finished:
         this.logger.verbose(`SubProcess was finished. Skipping ahead.`);
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade, identity);
 

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -80,8 +80,8 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
 
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
-        const callActivityNotYetExecuted: boolean = resumeToken === undefined;
-        if (callActivityNotYetExecuted) {
+        const subProcessNotYetExecuted: boolean = resumeToken === undefined;
+        if (subProcessNotYetExecuted) {
           const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade, identity);

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -76,7 +76,9 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        return this._continueAfterSuspend(flowNodeInstance, processTokenFacade, processModelFacade, identity);
+        const onSuspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+
+        return this._continueAfterSuspend(flowNodeInstance, onSuspendToken, processTokenFacade, processModelFacade, identity);
       case Runtime.Types.FlowNodeInstanceState.running:
 
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
@@ -102,45 +104,19 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
     }
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onSuspended" state.
-   *
-   * When the FlowNodeInstance was interrupted during this stage, we need to
-   * run the handler again, except for the "onSuspend" state change.
-   *
-   * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @param   identity           The requesting user's identity.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                      identity: IIdentity,
-                                     ): Promise<NextFlowNodeInfo> {
-    throw new Error('bla');
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                        identity: IIdentity,
+                                       ): Promise<NextFlowNodeInfo> {
+    throw new Error('Not implemented yet.');
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onResumed" state.
-   *
-   * Basically, the handler had already finished.
-   * The final result is only missing in the database.
-   *
-   * @async
-   * @param   resumeToken   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                     processTokenFacade: IProcessTokenFacade,
-                                     processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.subProcess.id, resumeToken.payload);
 

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -116,12 +116,9 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
                                       ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.subProcess.id, resumeToken.payload);
-
-    const nextNodeAfter: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.subProcess);
-
     await this.persistOnExit(resumeToken);
 
-    return new NextFlowNodeInfo(nextNodeAfter, resumeToken, processTokenFacade);
+    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
   }
 
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
@@ -217,6 +214,7 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
     const processWasTerminated: boolean = this._processTerminatedMessage !== undefined;
     if (processWasTerminated) {
       await this.flowNodeInstanceService.persistOnTerminate(flowNode, currentFlowNodeInstanceId, token);
+      await this.persistOnTerminate(token);
       const terminateEndEventId: string = this._processTerminatedMessage.flowNodeId;
       throw new InternalServerError(`Process was terminated through TerminateEndEvent "${terminateEndEventId}".`);
     }
@@ -231,5 +229,4 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
                                   currentFlowNodeInstanceId);
     }
   }
-
 }

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -95,9 +95,9 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new InternalServerError(`Cannot resume UserTask instance ${flowNodeInstance.id}, because it was terminated!`);
+        throw new InternalServerError(`Cannot resume SubProcess instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
-        throw new InternalServerError(`Cannot resume UserTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
+        throw new InternalServerError(`Cannot resume SubProcess instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }
   }
 

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -61,7 +61,6 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
@@ -76,11 +75,9 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
-        processTokenFacade.addResultForFlowNode(this.userTask.id, onExitToken);
 
-        return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
@@ -158,11 +155,35 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
                                     ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.userTask.id, resumeToken.payload);
-
     await this.persistOnExit(resumeToken);
+
     this._sendUserTaskFinishedNotification(resumeToken);
 
     return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
+  }
+
+  /**
+   * Resumes the given FlowNodeInstance from the point where it assumed the
+   * "onExit" state.
+   *
+   * Basically, the handler had already finished.
+   * We just need to return the info about the next FlowNode to run.
+   *
+   * @async
+   * @param   resumeToken        The ProcessToken stored after resuming the
+   *                             FlowNodeInstance.
+   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
+   * @param   processModelFacade The processModelFacade to use for resuming.
+   * @returns                    The Info for the next FlowNode to run.
+   */
+  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade,
+                                    ): Promise<NextFlowNodeInfo> {
+
+    processTokenFacade.addResultForFlowNode(this.userTask.id, onExitToken.payload);
+
+    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
   }
 
   private async _executeHandler(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -63,7 +63,7 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
       case Runtime.Types.FlowNodeInstanceState.suspended:
         const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
-        return this._continueAfterSuspend(suspendToken, processTokenFacade, processModelFacade);
+        return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
         const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
@@ -99,46 +99,19 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
     return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onSuspended" state.
-   *
-   * When the FlowNodeInstance was interrupted during this stage, we need to resubscribe
-   * to the EventHandler and wait for the UserTasks result.
-   *
-   * @async
-   * @param   onSuspendToken     The token the FlowNodeInstance had when it was
-   *                             suspended.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterSuspend(onSuspendToken: Runtime.Types.ProcessToken,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                     ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+                                        onSuspendToken: Runtime.Types.ProcessToken,
+                                        processTokenFacade: IProcessTokenFacade,
+                                        processModelFacade: IProcessModelFacade,
+                                       ): Promise<NextFlowNodeInfo> {
 
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onResumed" state.
-   *
-   * Basically, the UserTask was already finished.
-   * The final result is only missing in the database.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                     processTokenFacade: IProcessTokenFacade,
-                                     processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
+  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
+                                       processTokenFacade: IProcessTokenFacade,
+                                       processModelFacade: IProcessModelFacade,
+                                      ): Promise<NextFlowNodeInfo> {
 
     processTokenFacade.addResultForFlowNode(this.userTask.id, resumeToken.payload);
     await this.persistOnExit(resumeToken);

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -53,31 +53,25 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
                                    identity: IIdentity,
                                  ): Promise<NextFlowNodeInfo> {
 
-    function getFlowNodeInstanceTokenByType(tokenType: Runtime.Types.ProcessTokenType): Runtime.Types.ProcessToken {
-      return flowNodeInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
-        return token.type === tokenType;
-      });
-    }
-
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
-        const suspendToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
+        const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.running:
 
-        const resumeToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onResume);
+        const resumeToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onResume);
 
         const userTaskResultNotYetAwaited: boolean = resumeToken === undefined;
         if (userTaskResultNotYetAwaited) {
-          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+          const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
-        const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
+        const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
         return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.error:

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -1,3 +1,5 @@
+import {Logger} from 'loggerhythm';
+
 import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
@@ -30,6 +32,7 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
               userTaskModel: Model.Activities.UserTask) {
     super(flowNodeInstanceService, loggingApiService, metricsService, userTaskModel);
     this._eventAggregator = eventAggregator;
+    this.logger = new Logger(`processengine:user_task_handler:${userTaskModel.id}`);
   }
 
   private get userTask(): Model.Activities.UserTask {
@@ -41,6 +44,7 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
+    this.logger.verbose(`Executing UserTask instance ${this.flowNodeInstanceId}`);
     await this.persistOnEnter(token);
     await this.persistOnSuspend(token);
 
@@ -55,6 +59,7 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
 
     switch (flowNodeInstance.state) {
       case Runtime.Types.FlowNodeInstanceState.suspended:
+        this.logger.verbose(`FlowNodeInstance was left suspended. Waiting for the UserTask to be finished.`);
         const suspendToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onSuspend);
 
         return this._continueAfterSuspend(flowNodeInstance, suspendToken, processTokenFacade, processModelFacade);
@@ -64,22 +69,35 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
 
         const userTaskResultNotYetAwaited: boolean = resumeToken === undefined;
         if (userTaskResultNotYetAwaited) {
+          this.logger.verbose(`FlowNodeInstance was interrupted at the beginning. Resuming from the start.`);
           const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
           return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
+        this.logger.verbose(`The UserTask was already finished and the handler resumed. Finishing up the handler.`);
+
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
       case Runtime.Types.FlowNodeInstanceState.finished:
+        this.logger.verbose(`FlowNodeInstance was already finished. Skipping ahead.`);
         const onExitToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onExit);
 
-        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade);
+        return this._continueAfterExit(onExitToken, processTokenFacade, processModelFacade, identity);
+
       case Runtime.Types.FlowNodeInstanceState.error:
+        this.logger.error(`Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it previously exited with an error!`,
+                     flowNodeInstance.error);
         throw flowNodeInstance.error;
+
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new InternalServerError(`Cannot resume UserTask instance ${flowNodeInstance.id}, because it was terminated!`);
+        const terminatedError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because it was terminated!`;
+        this.logger.error(terminatedError);
+        throw new InternalServerError(terminatedError);
+
       default:
-        throw new InternalServerError(`Cannot resume UserTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
+        const invalidStateError: string = `Cannot resume FlowNodeInstance ${flowNodeInstance.id}, because its state cannot be determined!`;
+        this.logger.error(invalidStateError);
+        throw new InternalServerError(invalidStateError);
     }
   }
 

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -108,19 +108,6 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
     return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade);
   }
 
-  protected async _continueAfterResume(resumeToken: Runtime.Types.ProcessToken,
-                                       processTokenFacade: IProcessTokenFacade,
-                                       processModelFacade: IProcessModelFacade,
-                                      ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.userTask.id, resumeToken.payload);
-    await this.persistOnExit(resumeToken);
-
-    this._sendUserTaskFinishedNotification(resumeToken);
-
-    return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
-  }
-
   protected async _executeHandler(token: Runtime.Types.ProcessToken,
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade,

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -70,7 +70,9 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
 
         const userTaskResultNotYetAwaited: boolean = resumeToken === undefined;
         if (userTaskResultNotYetAwaited) {
-          return this._continueAfterEnter(flowNodeInstance, processTokenFacade, processModelFacade);
+          const onEnterToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onEnter);
+
+          return this._continueAfterEnter(onEnterToken, processTokenFacade, processModelFacade);
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
@@ -87,26 +89,10 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
     }
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onEnter" state.
-   *
-   * Basically, the handler was not yet executed, except for the initial
-   * state change.
-   *
-   * @async
-   * @param   flowNodeInstance   The FlowNodeInstance to resume.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterEnter(flowNodeInstance: Runtime.Types.FlowNodeInstance,
-                                    processTokenFacade: IProcessTokenFacade,
-                                    processModelFacade: IProcessModelFacade,
-                                   ): Promise<NextFlowNodeInfo> {
-
-    // When the FNI was interrupted directly after the onEnter state change, only one token will be present.
-    const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
+  protected async _continueAfterEnter(onEnterToken: Runtime.Types.ProcessToken,
+                                      processTokenFacade: IProcessTokenFacade,
+                                      processModelFacade: IProcessModelFacade,
+                                     ): Promise<NextFlowNodeInfo> {
 
     await this.persistOnSuspend(onEnterToken);
 
@@ -162,34 +148,10 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
     return this.getNextFlowNodeInfo(resumeToken, processTokenFacade, processModelFacade);
   }
 
-  /**
-   * Resumes the given FlowNodeInstance from the point where it assumed the
-   * "onExit" state.
-   *
-   * Basically, the handler had already finished.
-   * We just need to return the info about the next FlowNode to run.
-   *
-   * @async
-   * @param   resumeToken        The ProcessToken stored after resuming the
-   *                             FlowNodeInstance.
-   * @param   processTokenFacade The ProcessTokenFacade to use for resuming.
-   * @param   processModelFacade The processModelFacade to use for resuming.
-   * @returns                    The Info for the next FlowNode to run.
-   */
-  private async _continueAfterExit(onExitToken: Runtime.Types.ProcessToken,
-                                   processTokenFacade: IProcessTokenFacade,
-                                   processModelFacade: IProcessModelFacade,
-                                    ): Promise<NextFlowNodeInfo> {
-
-    processTokenFacade.addResultForFlowNode(this.userTask.id, onExitToken.payload);
-
-    return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
-  }
-
-  private async _executeHandler(token: Runtime.Types.ProcessToken,
-                                processTokenFacade: IProcessTokenFacade,
-                                processModelFacade: IProcessModelFacade,
-                               ): Promise<NextFlowNodeInfo> {
+  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade,
+                                 ): Promise<NextFlowNodeInfo> {
 
     const userTaskResult: any = await this._waitForUserTaskResult(token);
 

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -75,14 +75,16 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
         }
 
         return this._continueAfterResume(resumeToken, processTokenFacade, processModelFacade);
-      case Runtime.Types.FlowNodeInstanceState.error:
-      case Runtime.Types.FlowNodeInstanceState.terminated:
       case Runtime.Types.FlowNodeInstanceState.finished:
 
         const onExitToken: Runtime.Types.ProcessToken = getFlowNodeInstanceTokenByType(Runtime.Types.ProcessTokenType.onExit);
         processTokenFacade.addResultForFlowNode(this.userTask.id, onExitToken);
 
         return this.getNextFlowNodeInfo(onExitToken, processTokenFacade, processModelFacade);
+      case Runtime.Types.FlowNodeInstanceState.error:
+        throw flowNodeInstance.error;
+      case Runtime.Types.FlowNodeInstanceState.terminated:
+        throw new Error(`Cannot resume UserTask instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume UserTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -84,7 +84,7 @@ export class UserTaskHandler extends FlowNodeHandler<Model.Activities.UserTask> 
       case Runtime.Types.FlowNodeInstanceState.error:
         throw flowNodeInstance.error;
       case Runtime.Types.FlowNodeInstanceState.terminated:
-        throw new Error(`Cannot resume UserTask instance ${flowNodeInstance.id}, because it was terminated!`);
+        throw new InternalServerError(`Cannot resume UserTask instance ${flowNodeInstance.id}, because it was terminated!`);
       default:
         throw new InternalServerError(`Cannot resume UserTask instance ${flowNodeInstance.id}, because its state cannot be determined!`);
     }

--- a/src/runtime/engine/resume_process_serivce.ts
+++ b/src/runtime/engine/resume_process_serivce.ts
@@ -226,7 +226,7 @@ export class ResumeProcessService implements IResumeProcessService {
       processTerminationSubscription.dispose();
     }
 
-    return resultToken;
+    return resultToken.result;
   }
 
   private async _resumeFlowNode(flowNodeToResume: Model.Base.FlowNode,

--- a/src/runtime/engine/resume_process_serivce.ts
+++ b/src/runtime/engine/resume_process_serivce.ts
@@ -30,6 +30,7 @@ import {ProcessTokenFacade} from './process_token_facade';
 const logger: Logger = new Logger('processengine:runtime:resume_process_service');
 
 interface IProcessInstanceModelAssociation {
+  identity: IIdentity;
   processModelId: string;
   processInstanceId: string;
 }
@@ -100,7 +101,7 @@ export class ResumeProcessService implements IResumeProcessService {
       //
       // Lets say, Process A sends signals/messages to Process B,
       // then these processes must run in concert, not sequentially.
-      this.resumeProcessInstanceById(identity, processInstance.processModelId, processInstance.processInstanceId);
+      this.resumeProcessInstanceById(processInstance.identity, processInstance.processModelId, processInstance.processInstanceId);
     }
   }
 
@@ -379,6 +380,8 @@ export class ResumeProcessService implements IResumeProcessService {
         const newAssociation: IProcessInstanceModelAssociation = {
           processInstanceId: flowNodeInstance.processInstanceId,
           processModelId: flowNodeInstance.processModelId,
+          // TODO: This can be simplified, once the data models for FlowNodeInstance and ProcessToken have been refactored.
+          identity: flowNodeInstance.tokens[0].identity,
         };
         activeProcessInstances.push(newAssociation);
       }

--- a/src/runtime/engine/resume_process_serivce.ts
+++ b/src/runtime/engine/resume_process_serivce.ts
@@ -128,7 +128,7 @@ export class ResumeProcessService implements IResumeProcessService {
                entry.state === Runtime.Types.FlowNodeInstanceState.suspended;
       });
 
-    if (processHasActiveFlowNodeInstances) {
+    if (!processHasActiveFlowNodeInstances) {
       logger.info(`ProcessInstance ${processInstanceId} is not active anymore.`);
 
       return;
@@ -376,7 +376,7 @@ export class ResumeProcessService implements IResumeProcessService {
           return !token.caller;
         });
 
-      if (!processInstanceListHasNoMatchingEntry && flowNodeInstanceIsNotPartOfSubprocess) {
+      if (processInstanceListHasNoMatchingEntry && flowNodeInstanceIsNotPartOfSubprocess) {
         const newAssociation: IProcessInstanceModelAssociation = {
           processInstanceId: flowNodeInstance.processInstanceId,
           processModelId: flowNodeInstance.processModelId,

--- a/src/runtime/engine/resume_process_serivce.ts
+++ b/src/runtime/engine/resume_process_serivce.ts
@@ -1,13 +1,346 @@
-import {IResumeProcessService} from '@process-engine/process_engine_contracts';
+import {Logger} from 'loggerhythm';
+import * as moment from 'moment';
+import * as uuid from 'uuid';
 
+import {InternalServerError} from '@essential-projects/errors_ts';
+import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+import {ILoggingApi, LogLevel} from '@process-engine/logging_api_contracts';
+import {IMetricsApi} from '@process-engine/metrics_api_contracts';
+import {
+  BpmnType,
+  EndEventReachedMessage,
+  eventAggregatorSettings,
+  ICorrelationService,
+  IExecuteProcessService,
+  IFlowNodeHandler,
+  IFlowNodeHandlerFactory,
+  IFlowNodeInstanceService,
+  IProcessModelFacade,
+  IProcessModelService,
+  IProcessTokenFacade,
+  IProcessTokenResult,
+  IResumeProcessService,
+  Model,
+  NextFlowNodeInfo,
+  Runtime,
+  TerminateEndEventReachedMessage,
+} from '@process-engine/process_engine_contracts';
+
+import {ProcessModelFacade} from './process_model_facade';
+import {ProcessTokenFacade} from './process_token_facade';
+
+const logger: Logger = new Logger('processengine:runtime:resume_process_service');
+
+interface IProcessInstanceModelAssociation {
+  processModelId: string;
+  processInstanceId: string;
+}
+
+interface IProcessInstanceConfig {
+  correlationId: string;
+  processModelId: string;
+  processInstanceId: string;
+  processModelFacade: IProcessModelFacade;
+  startEvent: Model.Events.StartEvent;
+  processToken: Runtime.Types.ProcessToken;
+  processTokenFacade: IProcessTokenFacade;
+}
+
+/**
+ * This service is designed to find and resume process instances that were
+ * interrupted during a previous lifecycle of the ProcessEngine.
+ *
+ * It is strongly encouraged to only run this service ONCE when starting up
+ * the ProcessEngine!
+ *
+ * Trying to resume process instance during normal operation will have
+ * unpredictable consequences!
+ */
 export class ResumeProcessService implements IResumeProcessService {
 
-  public async findAndResumeInterruptedProcessInstances(): Promise<void> {
-    return Promise.resolve();
+  private readonly _eventAggregator: IEventAggregator;
+  private readonly _flowNodeHandlerFactory: IFlowNodeHandlerFactory;
+  private readonly _flowNodeInstanceService: IFlowNodeInstanceService;
+  private readonly _loggingApiService: ILoggingApi;
+  private readonly _metricsApiService: IMetricsApi;
+  private readonly _processModelService: IProcessModelService;
+
+  private processTerminatedMessage: TerminateEndEventReachedMessage;
+
+  constructor(eventAggregator: IEventAggregator,
+              flowNodeHandlerFactory: IFlowNodeHandlerFactory,
+              flowNodeInstanceService: IFlowNodeInstanceService,
+              loggingApiService: ILoggingApi,
+              metricsApiService: IMetricsApi,
+              processModelService: IProcessModelService) {
+
+    this._eventAggregator = eventAggregator;
+    this._flowNodeHandlerFactory = flowNodeHandlerFactory;
+    this._flowNodeInstanceService = flowNodeInstanceService;
+    this._loggingApiService = loggingApiService;
+    this._metricsApiService = metricsApiService;
+    this._processModelService = processModelService;
   }
 
-  public async resumeProcessInstanceById(processInstanceId: string): Promise<any> {
-    return Promise.resolve();
+  public async findAndResumeInterruptedProcessInstances(identity: IIdentity): Promise<void> {
+
+    logger.info('Resuming Process Instances that were not yet finished.');
+
+    // First get all active FlowNodeInstances.
+    // This doesn't account for processes with ParallelGateways.
+    const activeFlowNodeInstances: Array<Runtime.Types.FlowNodeInstance> =
+      await this._flowNodeInstanceService.queryActive();
+
+    // Now get the unique ProcessInstanceIds and ProcessModelIds from the list.
+    const activeProcessInstances: Array<IProcessInstanceModelAssociation> =
+      this._findProcessInstancesFromFlowNodeList(activeFlowNodeInstances);
+
+    logger.verbose(`Found ${activeProcessInstances.length} Process Instances to resume.`);
+
+    for (const processInstance of activeProcessInstances) {
+      // Do not await this, to avoid possible issues with Inter-Process communication.
+      //
+      // Lets say, Process A sends signals/messages to Process B,
+      // then these processes must run in concert, not sequentially.
+      this.resumeProcessInstanceById(identity, processInstance.processModelId, processInstance.processInstanceId);
+    }
   }
 
+  public async resumeProcessInstanceById(identity: IIdentity, processModelId: string, processInstanceId: string): Promise<any> {
+
+    logger.info(`Attempting to resume process instance with id ${processInstanceId}`);
+
+    // TODO: This could be refined, if the FlowNodeInstanceService had a `queryByProcessInstance` UseCase.
+    const flowNodeInstancesForProcessModel: Array<Runtime.Types.FlowNodeInstance> =
+      await this._flowNodeInstanceService.queryByProcessModel(processModelId);
+
+    const flowNodeInstancesForProcessInstance: Array<Runtime.Types.FlowNodeInstance> =
+      flowNodeInstancesForProcessModel.filter((entry: Runtime.Types.FlowNodeInstance): boolean => {
+        return entry.processInstanceId === processInstanceId;
+      });
+
+    // First check if there even are any FlowNodeInstances still active.
+    // There is no point in trying to resume anything that's already finished.
+    const processHasActiveFlowNodeInstances: boolean =
+      flowNodeInstancesForProcessInstance.some((entry: Runtime.Types.FlowNodeInstance): boolean => {
+        return entry.state === Runtime.Types.FlowNodeInstanceState.running ||
+               entry.state === Runtime.Types.FlowNodeInstanceState.suspended;
+      });
+
+    if (processHasActiveFlowNodeInstances) {
+      logger.info(`Processs instance ${processInstanceId} is not active anymore.`);
+
+      return;
+    }
+
+    const processInstanceConfig: IProcessInstanceConfig =
+      await this._createProcessInstanceConfig(identity, processModelId, processInstanceId, flowNodeInstancesForProcessInstance);
+
+    try {
+      this._logProcessResumed(processInstanceConfig.correlationId, processModelId, processInstanceId);
+      const result: any = await this._resumeProcessInstance(identity, processInstanceConfig);
+      this._logProcessFinished(processInstanceConfig.correlationId, processModelId, processInstanceId);
+
+      return result;
+    } catch (error) {
+      this._logProcessError(processInstanceConfig.correlationId, processModelId, processInstanceId, error);
+      throw error;
+    }
+  }
+
+  private async _createProcessInstanceConfig(identity: IIdentity,
+                                             processModelId: string,
+                                             processInstanceId: string,
+                                             flowNodeInstances: Array<Runtime.Types.FlowNodeInstance>,
+                                            ): Promise<IProcessInstanceConfig> {
+
+    const processModel: Model.Types.Process = await this._processModelService.getProcessModelById(identity, processModelId);
+    const processModelFacade: IProcessModelFacade = new ProcessModelFacade(processModel);
+
+    // Find the StartEvent the ProcessInstance was started with.
+    const startEventInstance: Runtime.Types.FlowNodeInstance =
+      flowNodeInstances.find((instance: Runtime.Types.FlowNodeInstance): boolean => {
+        return instance.flowNodeType === BpmnType.startEvent;
+      });
+
+    const startEvent: Model.Events.StartEvent = processModelFacade.getStartEventById(startEventInstance.flowNodeId);
+
+    // The initial ProcessToken will always be the payload that the StartEvent first received.
+    const initialToken: Runtime.Types.ProcessToken =
+      startEventInstance.tokens.find((token: Runtime.Types.ProcessToken): boolean => {
+        return token.type === Runtime.Types.ProcessTokenType.onEnter;
+      });
+
+    const processTokenFacade: IProcessTokenFacade =
+      new ProcessTokenFacade(processInstanceId, processModel.id, startEventInstance.correlationId, identity);
+
+    const processToken: Runtime.Types.ProcessToken = processTokenFacade.createProcessToken(initialToken.payload);
+    processTokenFacade.addResultForFlowNode(startEvent.id, initialToken.payload);
+
+    const processInstanceConfig: IProcessInstanceConfig = {
+      correlationId: startEventInstance.correlationId,
+      processModelId: processModel.id,
+      processInstanceId: processInstanceId,
+      processModelFacade: processModelFacade,
+      startEvent: startEvent,
+      processToken: processToken,
+      processTokenFacade: processTokenFacade,
+    };
+
+    return processInstanceConfig;
+  }
+
+  private async _resumeProcessInstance(identity: IIdentity, processInstanceConfig: IProcessInstanceConfig): Promise<any> {
+
+    const processTerminatedEvent: string = eventAggregatorSettings.routePaths.terminateEndEventReached
+      .replace(eventAggregatorSettings.routeParams.processInstanceId, processInstanceConfig.processInstanceId);
+
+    const processTerminationSubscription: ISubscription = this._eventAggregator
+      .subscribeOnce(processTerminatedEvent, async(message: TerminateEndEventReachedMessage): Promise<void> => {
+        this.processTerminatedMessage = message;
+      });
+
+    // TODO - WIP
+    // await this._resumeFlowNode(processInstanceConfig.startEvent,
+    //                            processInstanceConfig.processToken,
+    //                            processInstanceConfig.processTokenFacade,
+    //                            processInstanceConfig.processModelFacade,
+    //                            identity,
+    //                            undefined);
+
+    const resultToken: IProcessTokenResult = await this._getFinalResult(processInstanceConfig.processTokenFacade);
+
+    const processTerminationSubscriptionIsActive: boolean = processTerminationSubscription !== undefined;
+    if (processTerminationSubscriptionIsActive) {
+      processTerminationSubscription.dispose();
+    }
+
+    return resultToken;
+  }
+
+  /**
+   * Takes a list of FlowNodeInstances and picks out the unique ProcessModelIds
+   * and ProcessInstanceIds from each.
+   *
+   * Each Id is only stored once, to account for ProcessInstances with parallel
+   * running branches.
+   *
+   * Also, Subprocesses must be filtered out, because these are always handled
+   * by a CallActivityHandler or SubProcessHandler.
+   *
+   * @param   activeFlowNodeInstances The list of FlowNodeInstances from which
+   *                                  to get a list of ProcessInstances.
+   * @returns                         The list of ProcessInstances.
+   */
+  private _findProcessInstancesFromFlowNodeList(
+    activeFlowNodeInstances: Array<Runtime.Types.FlowNodeInstance>,
+  ): Array<IProcessInstanceModelAssociation> {
+
+    const activeProcessInstances: Array<IProcessInstanceModelAssociation> = [];
+
+    for (const flowNodeInstance of activeFlowNodeInstances) {
+      // Store each processInstanceId and processModelId only once,
+      // to account for processes with ParallelGateways.
+      const processInstanceListHasNoMatchingEntry: boolean =
+        !activeProcessInstances.some((entry: IProcessInstanceModelAssociation): boolean => {
+          return entry.processInstanceId === flowNodeInstance.processInstanceId;
+        });
+      //
+      // TODO: This business rule can be simplified, as soon as the callerId is located on the FlowNodeInstance,
+      // where it should have been in the first place.
+      const flowNodeInstanceIsNotPartOfSubprocess: boolean =
+        flowNodeInstance.tokens.some((token: Runtime.Types.ProcessToken): boolean => {
+          return !token.caller;
+        });
+
+      if (!processInstanceListHasNoMatchingEntry && flowNodeInstanceIsNotPartOfSubprocess) {
+        const newAssociation: IProcessInstanceModelAssociation = {
+          processInstanceId: flowNodeInstance.processInstanceId,
+          processModelId: flowNodeInstance.processModelId,
+        };
+        activeProcessInstances.push(newAssociation);
+      }
+    }
+
+    return activeProcessInstances;
+  }
+
+  /**
+   * Writes logs and metrics at the beginning of a ProcessInstance's resumption.
+   *
+   * @param correlationId     The ProcessInstance's CorrelationId.
+   * @param processModelId    The ProcessInstance's ProcessModelId.
+   * @param processInstanceId The ID of the ProcessInstance.
+   */
+  private _logProcessResumed(correlationId: string, processModelId: string, processInstanceId: string): void {
+
+    const startTime: moment.Moment = moment.utc();
+
+    this._loggingApiService.writeLogForProcessModel(correlationId,
+                                                    processModelId,
+                                                    processInstanceId,
+                                                    LogLevel.info,
+                                                    `Process instance resumed.`,
+                                                    startTime.toDate());
+
+    this._metricsApiService.writeOnProcessStarted(correlationId, processModelId, startTime);
+
+  }
+
+  /**
+   * Writes logs and metrics after a ProcessInstance finishes execution.
+   *
+   * @param correlationId     The ProcessInstance's CorrelationId.
+   * @param processModelId    The ProcessInstance's ProcessModelId.
+   * @param processInstanceId The ID of the ProcessInstance.
+   */
+  private _logProcessFinished(correlationId: string, processModelId: string, processInstanceId: string): void {
+
+    const endTime: moment.Moment = moment.utc();
+
+    this._metricsApiService.writeOnProcessFinished(correlationId, processModelId, endTime);
+
+    this._loggingApiService.writeLogForProcessModel(correlationId,
+                                                    processModelId,
+                                                    processInstanceId,
+                                                    LogLevel.info,
+                                                    `Process instance finished.`,
+                                                    endTime.toDate());
+  }
+
+  /**
+   * Writes logs and metrics when a ProcessInstances was interrupted by an error.
+   *
+   * @param correlationId     The ProcessInstance's CorrelationId.
+   * @param processModelId    The ProcessInstance's ProcessModelId.
+   * @param processInstanceId The ID of the ProcessInstance.
+   */
+  private _logProcessError(correlationId: string, processModelId: string, processInstanceId: string, error: Error): void {
+
+    const errorTime: moment.Moment = moment.utc();
+
+    this._metricsApiService.writeOnProcessError(correlationId, processModelId, error, errorTime);
+
+    this._loggingApiService.writeLogForProcessModel(correlationId,
+                                                    processModelId,
+                                                    processInstanceId,
+                                                    LogLevel.error,
+                                                    error.message,
+                                                    errorTime.toDate());
+  }
+
+  /**
+   * Gets the final result from the given ProcessTokenFacade.
+   *
+   * @param   processTokenFacade The facade containing the full ProcessToken.
+   * @returns                    The final result stored in the ProcessTokenFacade.
+   */
+  private async _getFinalResult(processTokenFacade: IProcessTokenFacade): Promise<IProcessTokenResult> {
+
+    const allResults: Array<IProcessTokenResult> = await processTokenFacade.getAllResults();
+
+    return allResults.pop();
+  }
 }

--- a/src/runtime/persistence/correlation_service.ts
+++ b/src/runtime/persistence/correlation_service.ts
@@ -107,6 +107,10 @@ export class CorrelationService implements ICorrelationService {
     const correlationsFromRepo: Array<Runtime.Types.CorrelationFromRepository> =
       await this._correlationRepository.getSubprocessesForProcessInstance(processInstanceId);
 
+    if (correlationsFromRepo.length === 0) {
+      return undefined;
+    }
+
     const activeFlowNodeInstances: Array<Runtime.Types.FlowNodeInstance> = await this._getActiveFlowNodeInstances();
 
     const correlation: Runtime.Types.Correlation =

--- a/src/runtime/persistence/correlation_service.ts
+++ b/src/runtime/persistence/correlation_service.ts
@@ -208,9 +208,10 @@ export class CorrelationService implements ICorrelationService {
           await this._processDefinitionRepository.getByHash(entry.processModelHash);
 
         const processModel: Runtime.Types.CorrelationProcessModel = new Runtime.Types.CorrelationProcessModel();
-        processModel.name = processDefinition.name;
+        processModel.processDefinitionName = processDefinition.name;
         processModel.xml = processDefinition.xml;
         processModel.hash = entry.processModelHash;
+        processModel.processModelId = entry.processModelId;
         processModel.processInstanceId = entry.processInstanceId;
         processModel.parentProcessInstanceId = entry.parentProcessInstanceId;
         processModel.createdAt = entry.createdAt;
@@ -313,11 +314,16 @@ export class CorrelationService implements ICorrelationService {
           await this._processDefinitionRepository.getByHash(correlation.processModelHash);
 
         const processModel: Runtime.Types.CorrelationProcessModel = new Runtime.Types.CorrelationProcessModel();
-        processModel.name = processDefinition.name;
+        processModel.processDefinitionName = processDefinition.name;
         processModel.hash = processDefinition.hash;
         processModel.xml = processDefinition.xml;
         processModel.createdAt = processDefinition.createdAt;
+        processModel.processModelId = correlation.processModelId;
         processModel.processInstanceId = correlation.processInstanceId;
+        processModel.parentProcessInstanceId = correlation.parentProcessInstanceId;
+        // For this UseCase, we can safely assuem the running-state,
+        // because we already made sure that only active correlations have been retrieved.
+        processModel.state = Runtime.Types.FlowNodeInstanceState.running;
 
         return processModel;
       });

--- a/src/runtime/persistence/correlation_service.ts
+++ b/src/runtime/persistence/correlation_service.ts
@@ -232,56 +232,17 @@ export class CorrelationService implements ICorrelationService {
   }
 
   /**
-   * Queries all "running" and "suspended" FlowNodeInstances from the repository
-   * and returns them as a concatenated result.
+   * Queries all "running" and "suspended" FlowNodeInstances from the repository.
    *
    * @async
-   * @returns All retrieved FlowNodeInstances.
+   * @returns All retrieved active FlowNodeInstances.
    */
   private async _getActiveFlowNodeInstances(): Promise<Array<Runtime.Types.FlowNodeInstance>> {
 
-    const runningFlowNodeInstances: Array<Runtime.Types.FlowNodeInstance> =
-      await this._getRunningFlowNodeInstances();
+    const activeFlowNodeInstances: Array<Runtime.Types.FlowNodeInstance> =
+      await this._flowNodeInstanceRepository.queryActive();
 
-    const suspendedFlowNodeInstances: Array<Runtime.Types.FlowNodeInstance> =
-      await this._getSuspendedFlowNodeInstances();
-
-    Array.prototype.push.apply(runningFlowNodeInstances, suspendedFlowNodeInstances);
-
-    return runningFlowNodeInstances;
-  }
-
-  /**
-   * Queries all running and suspended FlowNodeInstances from the repository
-   * and returns them as a concatenated result.
-   *
-   * @async
-   * @returns A list of all retrieved FlowNodeInstances.
-   */
-  private async _getRunningFlowNodeInstances(): Promise<Array<Runtime.Types.FlowNodeInstance>> {
-
-    const runningState: Runtime.Types.FlowNodeInstanceState = Runtime.Types.FlowNodeInstanceState.running;
-
-    const runningFlowNodeInstances: Array<Runtime.Types.FlowNodeInstance> =
-      await this._flowNodeInstanceRepository.queryByState(runningState);
-
-    return runningFlowNodeInstances;
-  }
-
-  /**
-   * Returns all running FlowNodeInstances from the repository.
-   *
-   * @async
-   * @returns A list of all retrieved FlowNodeInstances.
-   */
-  private async _getSuspendedFlowNodeInstances(): Promise<Array<Runtime.Types.FlowNodeInstance>> {
-
-    const suspendedState: Runtime.Types.FlowNodeInstanceState = Runtime.Types.FlowNodeInstanceState.suspended;
-
-    const suspendedFlowNodeInstances: Array<Runtime.Types.FlowNodeInstance> =
-      await this._flowNodeInstanceRepository.queryByState(suspendedState);
-
-    return suspendedFlowNodeInstances;
+    return activeFlowNodeInstances;
   }
 
   /**

--- a/src/runtime/persistence/correlation_service.ts
+++ b/src/runtime/persistence/correlation_service.ts
@@ -294,14 +294,14 @@ export class CorrelationService implements ICorrelationService {
   }
 
   /**
-   * Retrieves all entries from the correlation repository that have th
-   *  matching correlation ID.
+   * Retrieves all entries from the correlation repository that have the
+   * matching correlation ID.
    * Afterwards, the associated ProcessModelHashes are used to retrieve the
    * corresponding ProcessModels.
    *
    * @async
-   * @param   correlationId     The correlationId for which to get the ProcessModels.
-   * @returns                   The retrieved ProcessModels.
+   * @param   correlationId The correlationId for which to get the ProcessModels.
+   * @returns               The retrieved ProcessModels.
    */
   private async _getProcessDefinitionsForCorrelation(correlationId: string): Promise<Array<Runtime.Types.CorrelationProcessModel>> {
 
@@ -321,7 +321,7 @@ export class CorrelationService implements ICorrelationService {
         processModel.processModelId = correlation.processModelId;
         processModel.processInstanceId = correlation.processInstanceId;
         processModel.parentProcessInstanceId = correlation.parentProcessInstanceId;
-        // For this UseCase, we can safely assuem the running-state,
+        // For this UseCase, we can safely assume the running-state,
         // because we already made sure that only active correlations have been retrieved.
         processModel.state = Runtime.Types.FlowNodeInstanceState.running;
 


### PR DESCRIPTION
**Requires:**
https://github.com/process-engine/process_engine_contracts/pull/85

**Changes:**

1. Implement the `ResumeProcessService` for resuming previously interrupted Processes on startup.
2. Implement the `resume` function for each FlowNodeHandler.
3. Add logging to the more complex handlers.

The workflow for resuming ProcessInstances works like this:
- The `ResumeProcessService` retrieves all active FlowNodeInstances from the database
    - This includes only FlowNodeInstances that are marked as `suspended` or `running`
- The service then retrieves the list of active ProcessInstances from the retrieved list of FlowNodeInstances
    - This is done to avoid resuming the same ProcessInstance twice, which could happen, if a ProcessInstance with multiple parallel branches was interrupted
    - Also, this step filters out `CallActivities` and `SubProcesses`, since these must be resumed by their respective FlowNodeHandlers.
- Each retrieved ProcessInstance is "resumed" from the StartEvent by which it was originally started.
- The entire FlowNode chain is being traversed, using each FlowNodeHandlers `resume` function as the main entry point
    - To be able to correctly resume, each handlers `resume` function will get a matching FlowNodeInstance injected into it. This instance contains all information necessary for the handler to do its work.
- Depending on where the indiviudal FlowNode was interrupted, the FlowNodeHandler will continue to execute the FlowNode, until it is finished. The base class provides four separate hooks for this:
    - `continueAfterEnter`: The FlowNodeInstance was started but didn't get a chance to do its work. The handler is run from the start.
    - `continueAfterSuspend`: The FlowNodeInstance was interrupted while it was suspended. The handler will reconstruct the conditions necessary for placing it in suspension again and then wait for the key event that is supposed to resume the handler.
    - `continueAfterResume`: The FlowNodeInstance was already resumed by the key event that the handler is supposed to wait for. The handler will continue post-execution steps and then finish up.
    - `continueAfterExit`: The FlowNodeInstance was already finished. The handler just adds the instance's final result to the ProcessToken and then exits. This is actually the mechanism that allows us to effortlessly recreate ProcessTokens and resume parallel branches.
- When a `CallActivity` is to be resumed, the handler will:
    - either use the `ResumeProcessService` to resume the respective CallActivity
    - or, if the CallActivity was already finished during the downtime, retrieve the CallActivity result and use it as a result for the FlowNodeInstance.
- The handlers for `ExternalServiceTasks` will do much the same:
    - Check if an ExternalTask was already created. If not, it will be created and the handler waits for it to be processed, just as it normally would
    - If the ExternalTask was already created, the handler will check the state of that ExternalTask. 
         - If it was already finished, its result is retrieved and used as a result for the FlowNodeInstance.
         - If it was not yet finished, the handler will be placed in suspension again and wait for it to be finished
         - This is easily achieved, thanks to the separate persisting of ExternalTasks in a separate repository.
- `ParallelGateways` also work much the same, except that they only perform these steps for the FlowNodes that belong to their branches.
- Resuming a `SubProcess` must be done by the handler itself, not by the `ResumeProcessService`.
    - This is because Subprocesses do not contain xml code of their own and must therefore not create an entry in the `Correlation` repository, which would require the hash of a process model's xml. Doing so would inadvertently cause side effects with the correlation-related functions.
- When all resumable FlowNodeInstances have been successfully resumed and finished, the rest of the Process will continue normally. This means, the succeeding FlowNodeHandlers will no longer be run through their `resume` function, but `execute`.
    - Trying to `resume` them wouldn't make much sense anyway, because there is no instance specific data to pass to them. They were not run yet, after all.
- The ProcessInstance will then just continue to run as it normally would.

**Issues:**

Closes #167 

PR: #208

## How can others test the changes?

Try crashing a few ProcessInstances and then resume them on the next startup.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Fixing Security Issues   | `:lock:`             | 🔒     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️      |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️      |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
