### PR TITLE
🐛 Fix exclusive gateway error persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
@@ -81,7 +81,7 @@ export class ExclusiveGatewayHandler extends FlowNodeHandler<Model.Gateways.Excl
     token: Runtime.Types.ProcessToken,
     sequenceFlows: Array<Model.Types.SequenceFlow>,
     processTokenFacade: IProcessTokenFacade,
-): Promise<string> {
+  ): Promise<string> {
 
     const truthySequenceFlows: Array<Model.Types.SequenceFlow> = [];
 
@@ -117,7 +117,7 @@ export class ExclusiveGatewayHandler extends FlowNodeHandler<Model.Gateways.Excl
 
       await this.persistOnError(token, tooManySequenceFlowsError);
       throw tooManySequenceFlowsError;
-}
+    }
 
     const nextFlowNodeRef: string = truthySequenceFlows[0].targetRef;
 


### PR DESCRIPTION
**Changes:**

Perform a `persistOnError` for an ExclusiveSplitGateway, if one of its precondition fails.

PR: #210

## How can others test the changes?

Try running ExclusiveGateways that have no outgoing SequenceFlows with truthy conditions, or too many. The gateway will be persists as having been finished with errors.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Fixing Security Issues   | `:lock:`             | 🔒     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️      |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️      |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
