### PR TITLE
🐛 Fix token for parallel gateways

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
@@ -41,6 +41,7 @@ export class ParallelJoinGatewayHandler extends FlowNodeHandler<Model.Gateways.P
                                   processModelFacade: IProcessModelFacade,
                                   identity: IIdentity): Promise<NextFlowNodeInfo> {
     await this.persistOnExit(token);
+    await processTokenFacade.addResultForFlowNode(this.flowNode.id, token.payload);
 
     return this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
   }

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
@@ -93,14 +93,14 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
                                    processModelFacade,
                                    identity);
 
+    processTokenFacade.addResultForFlowNode(this.parallelGateway.id, token.payload);
+
     // Now await the resumption of all the branches. They will only run to the point where they encounter the Join-Gateway.
     const nextFlowNodeInfos: Array<NextFlowNodeInfo> = await Promise.all(parallelBranchExecutionPromises);
 
     // After all parallel branches have finished, the collective results are merged into the ProcessTokenFacade.
     const mergedToken: Runtime.Types.ProcessToken = await this._mergeTokenHistories(token, processTokenFacade, nextFlowNodeInfos);
     this.logger.verbose(`Finished ${nextFlowNodeInfos.length} parallel branches with final result:`, mergedToken.payload);
-
-    processTokenFacade.addResultForFlowNode(this.parallelGateway.id, token.payload);
 
     return new NextFlowNodeInfo(joinGateway, mergedToken, processTokenFacade);
   }
@@ -124,6 +124,7 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
 
     // The state change must be performed before the parallel branches are executed.
     // Otherwise, the Split Gateway will be in a running state, until all branches have finished.
+    processTokenFacade.addResultForFlowNode(this.parallelGateway.id, token.payload);
     await this.persistOnExit(token);
 
     // Now await the execution of all the branches. They will only run to the point where they encounter the Join-Gateway.
@@ -132,8 +133,6 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
     // After all parallel branches have finished, the collective results are merged into the ProcessTokenFacade.
     const mergedToken: Runtime.Types.ProcessToken = await this._mergeTokenHistories(token, processTokenFacade, nextFlowNodeInfos);
     this.logger.verbose(`Finished ${nextFlowNodeInfos.length} parallel branches with final result:`, mergedToken.payload);
-
-    processTokenFacade.addResultForFlowNode(this.parallelGateway.id, token.payload);
 
     return new NextFlowNodeInfo(joinGateway, mergedToken, processTokenFacade);
   }

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
@@ -1,3 +1,4 @@
+import * as clone from 'clone';
 import {Logger} from 'loggerhythm';
 
 import {InternalServerError, UnprocessableEntityError} from '@essential-projects/errors_ts';
@@ -96,8 +97,10 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
     const nextFlowNodeInfos: Array<NextFlowNodeInfo> = await Promise.all(parallelBranchExecutionPromises);
 
     // After all parallel branches have finished, the collective results are merged into the ProcessTokenFacade.
-    const mergedToken: Runtime.Types.ProcessToken = await this._mergeTokenHistories(processTokenFacade, nextFlowNodeInfos);
+    const mergedToken: Runtime.Types.ProcessToken = await this._mergeTokenHistories(token, processTokenFacade, nextFlowNodeInfos);
     this.logger.verbose(`Finished ${nextFlowNodeInfos.length} parallel branches with final result:`, mergedToken.payload);
+
+    processTokenFacade.addResultForFlowNode(this.parallelGateway.id, token.payload);
 
     return new NextFlowNodeInfo(joinGateway, mergedToken, processTokenFacade);
   }
@@ -127,8 +130,10 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
     const nextFlowNodeInfos: Array<NextFlowNodeInfo> = await Promise.all(parallelBranchExecutionPromises);
 
     // After all parallel branches have finished, the collective results are merged into the ProcessTokenFacade.
-    const mergedToken: Runtime.Types.ProcessToken = await this._mergeTokenHistories(processTokenFacade, nextFlowNodeInfos);
+    const mergedToken: Runtime.Types.ProcessToken = await this._mergeTokenHistories(token, processTokenFacade, nextFlowNodeInfos);
     this.logger.verbose(`Finished ${nextFlowNodeInfos.length} parallel branches with final result:`, mergedToken.payload);
+
+    processTokenFacade.addResultForFlowNode(this.parallelGateway.id, token.payload);
 
     return new NextFlowNodeInfo(joinGateway, mergedToken, processTokenFacade);
   }
@@ -330,11 +335,13 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
                                            flowNodeInstanceForFlowNode.id);
   }
 
-  private async _mergeTokenHistories(processTokenFacade: IProcessTokenFacade,
+  private async _mergeTokenHistories(currentToken: Runtime.Types.ProcessToken,
+                                     processTokenFacade: IProcessTokenFacade,
                                      nextFlowNodeInfos: Array<NextFlowNodeInfo>,
                                     ): Promise<Runtime.Types.ProcessToken> {
 
-    const mergedToken: Runtime.Types.ProcessToken = this._getEmptyProcessToken();
+    const mergedToken: Runtime.Types.ProcessToken = clone(currentToken);
+    mergedToken.payload = {};
     for (const nextFlowNodeInfo of nextFlowNodeInfos) {
       processTokenFacade.mergeTokenHistory(nextFlowNodeInfo.processTokenFacade);
       const nextFlowNodeInfoToken: Runtime.Types.ProcessToken = nextFlowNodeInfo.token;
@@ -343,32 +350,10 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
         await this.flowNodeInstanceService.queryByInstanceId(nextFlowNodeInfo.token.flowNodeInstanceId);
       const flowNodeId: string = flowNode.flowNodeId;
 
+      mergedToken.payload[flowNodeId] = nextFlowNodeInfoToken.payload;
       nextFlowNodeInfoToken.payload = {[`${flowNodeId}`]: nextFlowNodeInfoToken.payload};
-
-      const payloadIsNotEmpty: boolean = mergedToken.payload !== undefined;
-      if (payloadIsNotEmpty) {
-        Object.assign(nextFlowNodeInfoToken.payload, mergedToken.payload);
-      }
-
-      Object.assign(mergedToken, nextFlowNodeInfoToken);
     }
 
     return mergedToken;
-  }
-
-  private _getEmptyProcessToken(): Runtime.Types.ProcessToken {
-    const emptyProcessToken: Runtime.Types.ProcessToken = {
-      processInstanceId: undefined,
-      processModelId: undefined,
-      correlationId: undefined,
-      flowNodeInstanceId: undefined,
-      identity: undefined,
-      createdAt: undefined,
-      caller: undefined,
-      type: undefined,
-      payload: undefined,
-    };
-
-    return emptyProcessToken;
   }
 }


### PR DESCRIPTION
**Changes:**

1. Refrain from using `Object.assign` when merging token results for a ParallelGateway.
    - This fixes an issue where the ProcessTokenFacades contents would get wiped upon leaving the ParallelJoinGateway.
3. Add missing result tokens for ParallelJoinGateway. 


**Issues:**

Relates to https://github.com/process-engine/process_engine_runtime/issues/180

PR: #217

## How can others test the changes?

Use any process with parallel gateways and see that the tokens no longer get wiped. Using `token.current` and `token.history` is now possible again.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Fixing Security Issues   | `:lock:`             | 🔒     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️      |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️      |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
