### PR TITLE
🐛 Fix boundary event interruption

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/clone": "~0.1.30",
     "addict-ioc": "~2.5.1",
     "bluebird": "~3.5.2",
+    "bluebird-global": "~1.0.1",
     "clone": "~2.1.2",
     "loggerhythm": "~3.0.3",
     "mocha": "~5.2.0",
@@ -43,7 +44,7 @@
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "^1.1.3",
-    "@types/bluebird": "~3.5.24",
+    "@types/bluebird-global": "~3.5.9",
     "@types/express": "~4.16.0",
     "@types/node": "~10.12.2",
     "gulp": "~4.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@process-engine/consumer_api_contracts": "~1.3.0",
     "@process-engine/logging_api_contracts": "~0.3.0",
     "@process-engine/metrics_api_contracts": "~0.3.0",
-    "@process-engine/process_engine_contracts": "feature~fix_boundary_event_interruption",
+    "@process-engine/process_engine_contracts": "~36.0.0",
     "@types/clone": "~0.1.30",
     "addict-ioc": "~2.5.1",
     "bluebird": "~3.5.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@process-engine/consumer_api_contracts": "~1.3.0",
     "@process-engine/logging_api_contracts": "~0.3.0",
     "@process-engine/metrics_api_contracts": "~0.3.0",
-    "@process-engine/process_engine_contracts": "~35.0.0",
+    "@process-engine/process_engine_contracts": "feature~fix_boundary_event_interruption",
     "@types/clone": "~0.1.30",
     "addict-ioc": "~2.5.1",
     "bluebird": "~3.5.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "8.0.2",
+  "version": "8.1.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,12 @@
+import * as Bluebird from 'bluebird';
+
+Bluebird.config({
+  cancellation: true,
+});
+
+// This only needs to be imported once. After that, all is done.
+import * as BluebirdGlobal from 'bluebird-global';
+
 export * from './iam_service_mock';
 export * from './model';
 export * from './runtime';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ Bluebird.config({
   cancellation: true,
 });
 
-// This ensures that using Bluebird Promises as a return value for async
-// functions will not cause linter errors.
+// This allows us to use Bluebird Promises as return values for async functions.
+// These usually only take "Promise<T>".
 // Only needs to be imported once. After that, using Bluebird types is safe.
 import * as BluebirdGlobal from 'bluebird-global';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,8 @@ Bluebird.config({
   cancellation: true,
 });
 
-// This allows us to use Bluebird Promises as return values for async functions.
-// These usually only take "Promise<T>".
-// Only needs to be imported once. After that, using Bluebird types is safe.
-import * as BluebirdGlobal from 'bluebird-global';
+// This will make Bluebird the default Promise implementation throughout the core package.
+global.Promise = Bluebird;
 
 export * from './iam_service_mock';
 export * from './model';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,14 @@
 import * as Bluebird from 'bluebird';
 
+// By default, Promise-Cancellation is deactivated.
+// We need to activate it here in order to be able to use it.
 Bluebird.config({
   cancellation: true,
 });
 
-// This only needs to be imported once. After that, all is done.
+// This ensures that using Bluebird Promises as a return value for async
+// functions will not cause linter errors.
+// Only needs to be imported once. After that, using Bluebird types is safe.
 import * as BluebirdGlobal from 'bluebird-global';
 
 export * from './iam_service_mock';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ Bluebird.config({
 });
 
 // This will make Bluebird the default Promise implementation throughout the core package.
+// That means, we can still use the "Promise<T>" syntax and don't have to fall back to "Bluebird<T>"
 global.Promise = Bluebird;
 
 export * from './iam_service_mock';

--- a/src/runtime/engine/flow_node_handler/activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/activity_handler.ts
@@ -1,0 +1,45 @@
+import {ILoggingApi} from '@process-engine/logging_api_contracts';
+import {IMetricsApi} from '@process-engine/metrics_api_contracts';
+import {
+  IActivityHandler,
+  IFlowNodeInstanceService,
+  Model,
+  onInterruptionCallback,
+  Runtime,
+} from '@process-engine/process_engine_contracts';
+
+import {FlowNodeHandler} from './flow_node_handler';
+
+export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode>
+extends FlowNodeHandler<TFlowNode>
+implements IActivityHandler<TFlowNode> {
+
+  private _onInterruptedCallback: onInterruptionCallback;
+
+  constructor(flowNodeInstanceService: IFlowNodeInstanceService,
+              loggingApiService: ILoggingApi,
+              metricsApiService: IMetricsApi,
+              flowNode: TFlowNode) {
+    super(flowNodeInstanceService, loggingApiService, metricsApiService, flowNode);
+    // tslint:disable-next-line:no-empty
+    this._onInterruptedCallback = (): void => { };
+  }
+
+  protected get onInterruptedCallback(): onInterruptionCallback {
+    return this._onInterruptedCallback;
+  }
+
+  protected set onInterruptedCallback(value: onInterruptionCallback) {
+    this._onInterruptedCallback = value;
+  }
+
+  public async interrupt(token: Runtime.Types.ProcessToken, terminate?: boolean): Promise<void> {
+    await this.onInterruptedCallback(token);
+
+    if (terminate) {
+      return this.persistOnTerminate(token);
+    }
+
+    return this.persistOnExit(token);
+  }
+}

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
@@ -25,8 +25,16 @@ export class ErrorBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mode
     this._decoratedHandler = decoratedHandler;
   }
 
+  // Since ErrorBoundaryEvents can be part of a BoundaryEventChain, they must also implement this method,
+  // so they can tell their decorated handler to abort.
   public async interrupt(token: Runtime.Types.ProcessToken, terminate?: boolean): Promise<void> {
-    this._decoratedHandler.interrupt(token, terminate);
+
+    // TODO: This check can probably be removed as soon as CallActivities and SubprocessHandlers can be interrupted.
+    // But that will not happen until we are able to interrupt Subprocesses.
+    const handlerIsInterruptible: boolean = typeof (this._decoratedHandler as any).interrupt === 'function';
+    if (handlerIsInterruptible) {
+      this._decoratedHandler.interrupt(token, terminate);
+    }
   }
 
   protected async executeInternally(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
@@ -28,13 +28,7 @@ export class ErrorBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mode
   // Since ErrorBoundaryEvents can be part of a BoundaryEventChain, they must also implement this method,
   // so they can tell their decorated handler to abort.
   public async interrupt(token: Runtime.Types.ProcessToken, terminate?: boolean): Promise<void> {
-
-    // TODO: This check can probably be removed as soon as CallActivities and SubprocessHandlers can be interrupted.
-    // But that will not happen until we are able to interrupt Subprocesses.
-    const handlerIsInterruptible: boolean = typeof (this._decoratedHandler as any).interrupt === 'function';
-    if (handlerIsInterruptible) {
-      this._decoratedHandler.interrupt(token, terminate);
-    }
+    this._decoratedHandler.interrupt(token, terminate);
   }
 
   protected async executeInternally(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
@@ -11,23 +11,22 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler} from '../index';
-
+import {FlowNodeHandler, FlowNodeHandlerInterruptable} from '../index';
 export class ErrorBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
 
-  private _decoratedHandler: FlowNodeHandler<Model.Base.FlowNode>;
+  private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
-              decoratedHandler: FlowNodeHandler<Model.Base.FlowNode>,
+              decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>,
               errorBoundaryEventModel: Model.Events.BoundaryEvent) {
     super(flowNodeInstanceService, loggingApiService, metricsService, errorBoundaryEventModel);
     this._decoratedHandler = decoratedHandler;
   }
 
-  private get errorBoundaryEvent(): Model.Events.BoundaryEvent {
-    return super.flowNode;
+  public async interrupt(token: Runtime.Types.ProcessToken, terminate?: boolean): Promise<void> {
+    this._decoratedHandler.interrupt(token, terminate);
   }
 
   protected async executeInternally(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
@@ -11,8 +11,8 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler, FlowNodeHandlerInterruptable} from '../index';
-export class ErrorBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
+import {FlowNodeHandlerInterruptable} from '../index';
+export class ErrorBoundaryEventHandler extends FlowNodeHandlerInterruptable<Model.Events.BoundaryEvent> {
 
   private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;
 

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
@@ -11,15 +11,15 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from '../index';
-export class ErrorBoundaryEventHandler extends FlowNodeHandlerInterruptable<Model.Events.BoundaryEvent> {
+import {FlowNodeHandlerInterruptible} from '../index';
+export class ErrorBoundaryEventHandler extends FlowNodeHandlerInterruptible<Model.Events.BoundaryEvent> {
 
-  private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;
+  private _decoratedHandler: FlowNodeHandlerInterruptible<Model.Base.FlowNode>;
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
-              decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>,
+              decoratedHandler: FlowNodeHandlerInterruptible<Model.Base.FlowNode>,
               errorBoundaryEventModel: Model.Events.BoundaryEvent) {
     super(flowNodeInstanceService, loggingApiService, metricsService, errorBoundaryEventModel);
     this._decoratedHandler = decoratedHandler;

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/error_boundary_event_handler.ts
@@ -35,14 +35,10 @@ export class ErrorBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
     try {
-      const nextFlowNodeInfo: NextFlowNodeInfo
-        = await this._decoratedHandler.execute(token, processTokenFacade, processModelFacade, identity, this.previousFlowNodeInstanceId);
-
-      return nextFlowNodeInfo;
+      // Must use return await here to prevent unhandled rejections.
+      return await this._decoratedHandler.execute(token, processTokenFacade, processModelFacade, identity, this.previousFlowNodeInstanceId);
     } catch (err) {
-      const nextFlowNode: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.errorBoundaryEvent);
-
-      return new NextFlowNodeInfo(nextFlowNode, token, processTokenFacade);
+      return this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
     }
   }
 
@@ -52,17 +48,13 @@ export class ErrorBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
-
     try {
-      const nextFlowNodeInfo: NextFlowNodeInfo
-        = await this._decoratedHandler.resume(flowNodeInstance, processTokenFacade, processModelFacade, identity);
-
-      return nextFlowNodeInfo;
+      // Must use return await here to prevent unhandled rejections.
+      return await this._decoratedHandler.resume(flowNodeInstance, processTokenFacade, processModelFacade, identity);
     } catch (err) {
-      const nextFlowNode: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.errorBoundaryEvent);
+      const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 
-      return new NextFlowNodeInfo(nextFlowNode, onEnterToken, processTokenFacade);
+      return this.getNextFlowNodeInfo(onEnterToken, processTokenFacade, processModelFacade);
     }
   }
 }

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
@@ -50,7 +50,13 @@ export class MessageBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mo
       this.subscription.dispose();
     }
     this.handlerPromise.cancel();
-    this._decoratedHandler.interrupt(token, terminate);
+
+    // TODO: This check can probably be removed as soon as CallActivities and SubprocessHandlers can be interrupted.
+    // But that will not happen until we are able to interrupt Subprocesses.
+    const handlerIsInterruptible: boolean = typeof (this._decoratedHandler as any).interrupt === 'function';
+    if (handlerIsInterruptible) {
+      this._decoratedHandler.interrupt(token, terminate);
+    }
   }
 
   // TODO: Add support for non-interrupting message events.

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
@@ -14,12 +14,12 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {ActivityHandler, FlowNodeHandler} from '../index';
+import {FlowNodeHandler, FlowNodeHandlerInterruptable} from '../index';
 
 export class MessageBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
 
   private _eventAggregator: IEventAggregator;
-  private _decoratedHandler: ActivityHandler<Model.Base.FlowNode>;
+  private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;
 
   private messageReceived: boolean = false;
   private handlerHasFinished: boolean = false;
@@ -30,7 +30,7 @@ export class MessageBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bo
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
-              decoratedHandler: ActivityHandler<Model.Base.FlowNode>,
+              decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>,
               messageBoundaryEventModel: Model.Events.BoundaryEvent) {
     super(flowNodeInstanceService, loggingApiService, metricsService, messageBoundaryEventModel);
     this._eventAggregator = eventAggregator;

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
@@ -16,9 +16,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler, FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandlerInterruptable} from '../index';
 
-export class MessageBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
+export class MessageBoundaryEventHandler extends FlowNodeHandlerInterruptable<Model.Events.BoundaryEvent> {
 
   private _eventAggregator: IEventAggregator;
   private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
@@ -141,6 +141,8 @@ export class MessageBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bo
 
       // if the message was received before the decorated handler finished execution,
       // the MessageBoundaryEvent will be used to determine the next FlowNode to execute
+      const decoratedFlowNodeId: string = this._decoratedHandler.getFlowNode().id;
+      processTokenFacade.addResultForFlowNode(decoratedFlowNodeId, token.payload);
       processTokenFacade.addResultForFlowNode(this.messageBoundaryEvent.id, token.payload);
 
       const nextNodeAfterBoundaryEvent: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.messageBoundaryEvent);

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
@@ -48,13 +48,7 @@ export class MessageBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mo
       this.subscription.dispose();
     }
     this.handlerPromise.cancel();
-
-    // TODO: This check can probably be removed as soon as CallActivities and SubprocessHandlers can be interrupted.
-    // But that will not happen until we are able to interrupt Subprocesses.
-    const handlerIsInterruptible: boolean = typeof (this._decoratedHandler as any).interrupt === 'function';
-    if (handlerIsInterruptible) {
-      this._decoratedHandler.interrupt(token, terminate);
-    }
+    this._decoratedHandler.interrupt(token, terminate);
   }
 
   // TODO: Add support for non-interrupting message events.

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
@@ -110,15 +110,15 @@ export class MessageBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bo
     });
   }
 
-  private async _subscribeToMessageEvent(resolveFunc: Function,
-                                         token: Runtime.Types.ProcessToken,
-                                         processTokenFacade: IProcessTokenFacade,
-                                         processModelFacade: IProcessModelFacade): Promise<void> {
+  private _subscribeToMessageEvent(resolveFunc: Function,
+                                   token: Runtime.Types.ProcessToken,
+                                   processTokenFacade: IProcessTokenFacade,
+                                   processModelFacade: IProcessModelFacade): void {
 
     const messageBoundaryEventName: string = eventAggregatorSettings.routePaths.messageEventReached
       .replace(eventAggregatorSettings.routeParams.messageReference, this.messageBoundaryEvent.messageEventDefinition.name);
 
-    const messageReceivedCallback: any = async(message: MessageEventReachedMessage): Promise<void> => {
+    const messageReceivedCallback: any = (message: MessageEventReachedMessage): void => {
 
       if (this.subscription) {
         this.subscription.dispose();
@@ -133,7 +133,7 @@ export class MessageBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bo
 
       // if the message was received before the decorated handler finished execution,
       // the MessageBoundaryEvent will be used to determine the next FlowNode to execute
-      await processTokenFacade.addResultForFlowNode(this.messageBoundaryEvent.id, token.payload);
+      processTokenFacade.addResultForFlowNode(this.messageBoundaryEvent.id, token.payload);
 
       const nextNodeAfterBoundaryEvent: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.messageBoundaryEvent);
 

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
@@ -14,12 +14,12 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler} from '../index';
+import {ActivityHandler, FlowNodeHandler} from '../index';
 
 export class MessageBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
 
   private _eventAggregator: IEventAggregator;
-  private _decoratedHandler: FlowNodeHandler<Model.Base.FlowNode>;
+  private _decoratedHandler: ActivityHandler<Model.Base.FlowNode>;
 
   private messageReceived: boolean = false;
   private handlerHasFinished: boolean = false;
@@ -30,7 +30,7 @@ export class MessageBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bo
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
-              decoratedHandler: FlowNodeHandler<Model.Base.FlowNode>,
+              decoratedHandler: ActivityHandler<Model.Base.FlowNode>,
               messageBoundaryEventModel: Model.Events.BoundaryEvent) {
     super(flowNodeInstanceService, loggingApiService, metricsService, messageBoundaryEventModel);
     this._eventAggregator = eventAggregator;
@@ -117,8 +117,8 @@ export class MessageBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bo
         return;
       }
       this.messageReceived = true;
-
       token.payload = message.currentToken;
+      this._decoratedHandler.interrupt(token);
 
       // if the message was received before the decorated handler finished execution,
       // the MessageBoundaryEvent will be used to determine the next FlowNode to execute

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
@@ -16,12 +16,12 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandlerInterruptible} from '../index';
 
-export class MessageBoundaryEventHandler extends FlowNodeHandlerInterruptable<Model.Events.BoundaryEvent> {
+export class MessageBoundaryEventHandler extends FlowNodeHandlerInterruptible<Model.Events.BoundaryEvent> {
 
   private _eventAggregator: IEventAggregator;
-  private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;
+  private _decoratedHandler: FlowNodeHandlerInterruptible<Model.Base.FlowNode>;
 
   private messageReceived: boolean = false;
   private handlerHasFinished: boolean = false;
@@ -33,7 +33,7 @@ export class MessageBoundaryEventHandler extends FlowNodeHandlerInterruptable<Mo
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
-              decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>,
+              decoratedHandler: FlowNodeHandlerInterruptible<Model.Base.FlowNode>,
               messageBoundaryEventModel: Model.Events.BoundaryEvent) {
     super(flowNodeInstanceService, loggingApiService, metricsService, messageBoundaryEventModel);
     this._eventAggregator = eventAggregator;

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/message_boundary_event_handler.ts
@@ -1,5 +1,3 @@
-import * as Bluebird from 'bluebird';
-
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
@@ -26,7 +24,7 @@ export class MessageBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mo
   private messageReceived: boolean = false;
   private handlerHasFinished: boolean = false;
 
-  private handlerPromise: Bluebird<NextFlowNodeInfo>;
+  private handlerPromise: Promise<NextFlowNodeInfo>;
   private subscription: ISubscription;
 
   constructor(eventAggregator: IEventAggregator,
@@ -65,7 +63,7 @@ export class MessageBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mo
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
-    this.handlerPromise = new Bluebird<NextFlowNodeInfo>(async(resolve: Function): Promise<void> => {
+    this.handlerPromise = new Promise<NextFlowNodeInfo>(async(resolve: Function): Promise<void> => {
 
       this._subscribeToMessageEvent(resolve, token, processTokenFacade, processModelFacade);
 
@@ -96,7 +94,7 @@ export class MessageBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mo
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    this.handlerPromise = new Bluebird<NextFlowNodeInfo>(async(resolve: Function): Promise<void> => {
+    this.handlerPromise = new Promise<NextFlowNodeInfo>(async(resolve: Function): Promise<void> => {
 
       const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
 

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
@@ -14,12 +14,12 @@ import {
   SignalEventReachedMessage,
 } from '@process-engine/process_engine_contracts';
 
-import {ActivityHandler, FlowNodeHandler} from '../index';
+import {FlowNodeHandler, FlowNodeHandlerInterruptable} from '../index';
 
 export class SignalBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
 
   private _eventAggregator: IEventAggregator;
-  private _decoratedHandler: ActivityHandler<Model.Base.FlowNode>;
+  private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;
 
   private signalReceived: boolean = false;
   private handlerHasFinished: boolean = false;
@@ -30,7 +30,7 @@ export class SignalBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bou
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
-              decoratedHandler: ActivityHandler<Model.Base.FlowNode>,
+              decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>,
               signalBoundaryEventModel: Model.Events.BoundaryEvent) {
     super(flowNodeInstanceService, loggingApiService, metricsService, signalBoundaryEventModel);
     this._eventAggregator = eventAggregator;

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
@@ -1,5 +1,3 @@
-import * as Bluebird from 'bluebird';
-
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
@@ -26,7 +24,7 @@ export class SignalBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mod
   private signalReceived: boolean = false;
   private handlerHasFinished: boolean = false;
 
-  private handlerPromise: Bluebird<NextFlowNodeInfo>;
+  private handlerPromise: Promise<NextFlowNodeInfo>;
   private subscription: ISubscription;
 
   constructor(eventAggregator: IEventAggregator,
@@ -65,7 +63,7 @@ export class SignalBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mod
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
-    this.handlerPromise = new Bluebird<NextFlowNodeInfo>(async(resolve: Function): Promise<void> => {
+    this.handlerPromise = new Promise<NextFlowNodeInfo>(async(resolve: Function): Promise<void> => {
 
       this._subscribeToSignalEvent(resolve, token, processTokenFacade, processModelFacade);
 
@@ -96,7 +94,7 @@ export class SignalBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mod
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    this.handlerPromise = new Bluebird<NextFlowNodeInfo>(async(resolve: Function): Promise<void> => {
+    this.handlerPromise = new Promise<NextFlowNodeInfo>(async(resolve: Function): Promise<void> => {
 
       const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.tokens[0];
 

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
@@ -50,7 +50,13 @@ export class SignalBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mod
       this.subscription.dispose();
     }
     this.handlerPromise.cancel();
-    this._decoratedHandler.interrupt(token, terminate);
+
+    // TODO: This check can probably be removed as soon as CallActivities and SubprocessHandlers can be interrupted.
+    // But that will not happen until we are able to interrupt Subprocesses.
+    const handlerIsInterruptible: boolean = typeof (this._decoratedHandler as any).interrupt === 'function';
+    if (handlerIsInterruptible) {
+      this._decoratedHandler.interrupt(token, terminate);
+    }
   }
 
   // TODO: Add support for non-interrupting signal events.

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
@@ -16,12 +16,12 @@ import {
   SignalEventReachedMessage,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandlerInterruptible} from '../index';
 
-export class SignalBoundaryEventHandler extends FlowNodeHandlerInterruptable<Model.Events.BoundaryEvent> {
+export class SignalBoundaryEventHandler extends FlowNodeHandlerInterruptible<Model.Events.BoundaryEvent> {
 
   private _eventAggregator: IEventAggregator;
-  private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;
+  private _decoratedHandler: FlowNodeHandlerInterruptible<Model.Base.FlowNode>;
 
   private signalReceived: boolean = false;
   private handlerHasFinished: boolean = false;
@@ -33,7 +33,7 @@ export class SignalBoundaryEventHandler extends FlowNodeHandlerInterruptable<Mod
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
-              decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>,
+              decoratedHandler: FlowNodeHandlerInterruptible<Model.Base.FlowNode>,
               signalBoundaryEventModel: Model.Events.BoundaryEvent) {
     super(flowNodeInstanceService, loggingApiService, metricsService, signalBoundaryEventModel);
     this._eventAggregator = eventAggregator;

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
@@ -140,6 +140,8 @@ export class SignalBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bou
 
       // if the signal was received before the decorated handler finished execution,
       // the signalBoundaryEvent will be used to determine the next FlowNode to execute
+      const decoratedFlowNodeId: string = this._decoratedHandler.getFlowNode().id;
+      processTokenFacade.addResultForFlowNode(decoratedFlowNodeId, token.payload);
       processTokenFacade.addResultForFlowNode(this.signalBoundaryEvent.id, token.payload);
 
       const nextNodeAfterBoundaryEvent: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.signalBoundaryEvent);

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
@@ -14,12 +14,12 @@ import {
   SignalEventReachedMessage,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler} from '../index';
+import {ActivityHandler, FlowNodeHandler} from '../index';
 
 export class SignalBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
 
   private _eventAggregator: IEventAggregator;
-  private _decoratedHandler: FlowNodeHandler<Model.Base.FlowNode>;
+  private _decoratedHandler: ActivityHandler<Model.Base.FlowNode>;
 
   private signalReceived: boolean = false;
   private handlerHasFinished: boolean = false;
@@ -30,7 +30,7 @@ export class SignalBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bou
               flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
-              decoratedHandler: FlowNodeHandler<Model.Base.FlowNode>,
+              decoratedHandler: ActivityHandler<Model.Base.FlowNode>,
               signalBoundaryEventModel: Model.Events.BoundaryEvent) {
     super(flowNodeInstanceService, loggingApiService, metricsService, signalBoundaryEventModel);
     this._eventAggregator = eventAggregator;
@@ -117,8 +117,8 @@ export class SignalBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bou
         return;
       }
       this.signalReceived = true;
-
       token.payload = signal.currentToken;
+      this._decoratedHandler.interrupt(token);
 
       // if the signal was received before the decorated handler finished execution,
       // the signalBoundaryEvent will be used to determine the next FlowNode to execute

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
@@ -48,13 +48,7 @@ export class SignalBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mod
       this.subscription.dispose();
     }
     this.handlerPromise.cancel();
-
-    // TODO: This check can probably be removed as soon as CallActivities and SubprocessHandlers can be interrupted.
-    // But that will not happen until we are able to interrupt Subprocesses.
-    const handlerIsInterruptible: boolean = typeof (this._decoratedHandler as any).interrupt === 'function';
-    if (handlerIsInterruptible) {
-      this._decoratedHandler.interrupt(token, terminate);
-    }
+    this._decoratedHandler.interrupt(token, terminate);
   }
 
   // TODO: Add support for non-interrupting signal events.

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
@@ -16,9 +16,9 @@ import {
   SignalEventReachedMessage,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler, FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandlerInterruptable} from '../index';
 
-export class SignalBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
+export class SignalBoundaryEventHandler extends FlowNodeHandlerInterruptable<Model.Events.BoundaryEvent> {
 
   private _eventAggregator: IEventAggregator;
   private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/signal_boundary_event_handler.ts
@@ -108,15 +108,15 @@ export class SignalBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bou
     });
   }
 
-  private async _subscribeToSignalEvent(resolveFunc: Function,
-                                        token: Runtime.Types.ProcessToken,
-                                        processTokenFacade: IProcessTokenFacade,
-                                        processModelFacade: IProcessModelFacade): Promise<void> {
+  private _subscribeToSignalEvent(resolveFunc: Function,
+                                  token: Runtime.Types.ProcessToken,
+                                  processTokenFacade: IProcessTokenFacade,
+                                  processModelFacade: IProcessModelFacade): void {
 
     const signalBoundaryEventName: string = eventAggregatorSettings.routePaths.signalEventReached
       .replace(eventAggregatorSettings.routeParams.signalReference, this.signalBoundaryEvent.signalEventDefinition.name);
 
-    const signalReceivedCallback: any = async(signal: SignalEventReachedMessage): Promise<void> => {
+    const signalReceivedCallback: any = (signal: SignalEventReachedMessage): void => {
 
       if (this.subscription) {
         this.subscription.dispose();
@@ -131,7 +131,7 @@ export class SignalBoundaryEventHandler extends FlowNodeHandler<Model.Events.Bou
 
       // if the signal was received before the decorated handler finished execution,
       // the signalBoundaryEvent will be used to determine the next FlowNode to execute
-      await processTokenFacade.addResultForFlowNode(this.signalBoundaryEvent.id, token.payload);
+      processTokenFacade.addResultForFlowNode(this.signalBoundaryEvent.id, token.payload);
 
       const nextNodeAfterBoundaryEvent: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.signalBoundaryEvent);
 

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -15,18 +15,18 @@ import {
 } from '@process-engine/process_engine_contracts';
 
 import {Logger} from 'loggerhythm';
-import {FlowNodeHandler} from '../index';
+import {ActivityHandler, FlowNodeHandler} from '../index';
 
 export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
 
-  private _decoratedHandler: FlowNodeHandler<Model.Base.FlowNode>;
+  private _decoratedHandler: ActivityHandler<Model.Base.FlowNode>;
   private _timerFacade: ITimerFacade;
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
               timerFacade: ITimerFacade,
-              decoratedHandler: FlowNodeHandler<Model.Base.FlowNode>,
+              decoratedHandler: ActivityHandler<Model.Base.FlowNode>,
               timerBoundaryEventModel: Model.Events.BoundaryEvent) {
     super(flowNodeInstanceService, loggingApiService, metricsService, timerBoundaryEventModel);
     this._decoratedHandler = decoratedHandler;
@@ -61,6 +61,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
             return;
           }
           timerHasElapsed = true;
+          this._decoratedHandler.interrupt(token);
 
           // if the timer elapsed before the decorated handler finished execution,
           // the TimerBoundaryEvent will be used to determine the next FlowNode to execute
@@ -117,6 +118,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
             return;
           }
           timerHasElapsed = true;
+          this._decoratedHandler.interrupt(onEnterToken);
 
           // if the timer elapsed before the decorated handler finished resumption,
           // the TimerBoundaryEvent will be used to determine the next FlowNode to execute

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -17,9 +17,9 @@ import {
 } from '@process-engine/process_engine_contracts';
 
 import {Logger} from 'loggerhythm';
-import {FlowNodeHandler, FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandlerInterruptable} from '../index';
 
-export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
+export class TimerBoundaryEventHandler extends FlowNodeHandlerInterruptable<Model.Events.BoundaryEvent> {
 
   private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;
   private _timerFacade: ITimerFacade;

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -52,7 +52,13 @@ export class TimerBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mode
       this.timerSubscription.dispose();
     }
     this.handlerPromise.cancel();
-    this._decoratedHandler.interrupt(token, terminate);
+
+    // TODO: This check can probably be removed as soon as CallActivities and SubprocessHandlers can be interrupted.
+    // But that will not happen until we are able to interrupt Subprocesses.
+    const handlerIsInterruptible: boolean = typeof (this._decoratedHandler as any).interrupt === 'function';
+    if (handlerIsInterruptible) {
+      this._decoratedHandler.interrupt(token, terminate);
+    }
   }
 
   protected async executeInternally(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -17,11 +17,11 @@ import {
 } from '@process-engine/process_engine_contracts';
 
 import {Logger} from 'loggerhythm';
-import {FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandlerInterruptible} from '../index';
 
-export class TimerBoundaryEventHandler extends FlowNodeHandlerInterruptable<Model.Events.BoundaryEvent> {
+export class TimerBoundaryEventHandler extends FlowNodeHandlerInterruptible<Model.Events.BoundaryEvent> {
 
-  private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;
+  private _decoratedHandler: FlowNodeHandlerInterruptible<Model.Base.FlowNode>;
   private _timerFacade: ITimerFacade;
 
   private timerHasElapsed: boolean = false;
@@ -34,7 +34,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandlerInterruptable<Mode
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
               timerFacade: ITimerFacade,
-              decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>,
+              decoratedHandler: FlowNodeHandlerInterruptible<Model.Base.FlowNode>,
               timerBoundaryEventModel: Model.Events.BoundaryEvent) {
     super(flowNodeInstanceService, loggingApiService, metricsService, timerBoundaryEventModel);
     this._decoratedHandler = decoratedHandler;

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -1,5 +1,3 @@
-import * as Bluebird from 'bluebird';
-
 import {ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
@@ -27,7 +25,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mode
   private timerHasElapsed: boolean = false;
   private hasHandlerFinished: boolean = false;
 
-  private handlerPromise: Bluebird<NextFlowNodeInfo>;
+  private handlerPromise: Promise<NextFlowNodeInfo>;
   private timerSubscription: ISubscription;
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
@@ -66,7 +64,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mode
                                     processModelFacade: IProcessModelFacade,
                                     identity: IIdentity): Promise<NextFlowNodeInfo> {
 
-    this.handlerPromise = new Bluebird<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<NextFlowNodeInfo> => {
+    this.handlerPromise = new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<NextFlowNodeInfo> => {
 
       this._executeTimer(resolve, token, processTokenFacade, processModelFacade);
 
@@ -97,7 +95,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mode
                                    identity: IIdentity,
                                   ): Promise<NextFlowNodeInfo> {
 
-    this.handlerPromise = new Bluebird<NextFlowNodeInfo> (async(resolve: Function, reject: Function): Promise<NextFlowNodeInfo> => {
+    this.handlerPromise = new Promise<NextFlowNodeInfo> (async(resolve: Function, reject: Function): Promise<NextFlowNodeInfo> => {
 
       const onEnterToken: Runtime.Types.ProcessToken = flowNodeInstance.getTokenByType(Runtime.Types.ProcessTokenType.onEnter);
       this._executeTimer(resolve, onEnterToken, processTokenFacade, processModelFacade);

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -15,18 +15,18 @@ import {
 } from '@process-engine/process_engine_contracts';
 
 import {Logger} from 'loggerhythm';
-import {ActivityHandler, FlowNodeHandler} from '../index';
+import {FlowNodeHandler, FlowNodeHandlerInterruptable} from '../index';
 
 export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.BoundaryEvent> {
 
-  private _decoratedHandler: ActivityHandler<Model.Base.FlowNode>;
+  private _decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>;
   private _timerFacade: ITimerFacade;
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,
               metricsService: IMetricsApi,
               timerFacade: ITimerFacade,
-              decoratedHandler: ActivityHandler<Model.Base.FlowNode>,
+              decoratedHandler: FlowNodeHandlerInterruptable<Model.Base.FlowNode>,
               timerBoundaryEventModel: Model.Events.BoundaryEvent) {
     super(flowNodeInstanceService, loggingApiService, metricsService, timerBoundaryEventModel);
     this._decoratedHandler = decoratedHandler;

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -142,6 +142,8 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
 
       // if the timer elapsed before the decorated handler finished execution,
       // the TimerBoundaryEvent will be used to determine the next FlowNode to execute
+      const decoratedFlowNodeId: string = this._decoratedHandler.getFlowNode().id;
+      processTokenFacade.addResultForFlowNode(decoratedFlowNodeId, token.payload);
       processTokenFacade.addResultForFlowNode(this.timerBoundaryEvent.id, token.payload);
 
       const nextNodeAfterBoundaryEvent: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.timerBoundaryEvent);

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -50,13 +50,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandlerInterruptible<Mode
       this.timerSubscription.dispose();
     }
     this.handlerPromise.cancel();
-
-    // TODO: This check can probably be removed as soon as CallActivities and SubprocessHandlers can be interrupted.
-    // But that will not happen until we are able to interrupt Subprocesses.
-    const handlerIsInterruptible: boolean = typeof (this._decoratedHandler as any).interrupt === 'function';
-    if (handlerIsInterruptible) {
-      this._decoratedHandler.interrupt(token, terminate);
-    }
+    this._decoratedHandler.interrupt(token, terminate);
   }
 
   protected async executeInternally(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/boundary_event_handlers/timer_boundary_event_handler.ts
@@ -118,9 +118,9 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
 
     const timerType: TimerDefinitionType = this._timerFacade.parseTimerDefinitionType(this.timerBoundaryEvent.timerEventDefinition);
     const timerValueFromDefinition: string = this._timerFacade.parseTimerDefinitionValue(this.timerBoundaryEvent.timerEventDefinition);
-    const timerValue: string = await this._executeTimerExpressionIfNeeded(timerValueFromDefinition, processTokenFacade);
+    const timerValue: string = this._executeTimerExpressionIfNeeded(timerValueFromDefinition, processTokenFacade);
 
-    const timerElapsed: any = async(): Promise<void> => {
+    const timerElapsed: any = (): void => {
 
       // No matter what timer type is used, a TimerBoundaryEvent can only ever run once,
       // given that the decorated handler itself can only run once.
@@ -136,7 +136,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
 
       // if the timer elapsed before the decorated handler finished execution,
       // the TimerBoundaryEvent will be used to determine the next FlowNode to execute
-      await processTokenFacade.addResultForFlowNode(this.timerBoundaryEvent.id, token.payload);
+      processTokenFacade.addResultForFlowNode(this.timerBoundaryEvent.id, token.payload);
 
       const nextNodeAfterBoundaryEvent: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.timerBoundaryEvent);
       resolveFunc(new NextFlowNodeInfo(nextNodeAfterBoundaryEvent, token, processTokenFacade));
@@ -145,7 +145,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
     this.timerSubscription = this._timerFacade.initializeTimer(this.timerBoundaryEvent, timerType, timerValue, timerElapsed);
   }
 
-  private async _executeTimerExpressionIfNeeded(timerExpression: string, processTokenFacade: IProcessTokenFacade): Promise<string> {
+  private _executeTimerExpressionIfNeeded(timerExpression: string, processTokenFacade: IProcessTokenFacade): string {
     const tokenVariableName: string = 'token';
     const isConstantTimerExpression: boolean = !timerExpression.includes(tokenVariableName);
 
@@ -153,7 +153,7 @@ export class TimerBoundaryEventHandler extends FlowNodeHandler<Model.Events.Boun
       return timerExpression;
     }
 
-    const tokenData: any = await processTokenFacade.getOldTokenFormat();
+    const tokenData: any = processTokenFacade.getOldTokenFormat();
 
     try {
       const functionString: string = `return ${timerExpression}`;

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -23,9 +23,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler} from './index';
+import {FlowNodeHandlerInterruptible} from './index';
 
-export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallActivity> {
+export class CallActivityHandler extends FlowNodeHandlerInterruptible<Model.Activities.CallActivity> {
 
   private _consumerApiService: IConsumerApi;
   private _correlationService: ICorrelationService;
@@ -47,6 +47,11 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
 
   private get callActivity(): Model.Activities.CallActivity {
     return super.flowNode;
+  }
+
+  // TODO: We can't interrupt a Subprocess yet, so this will remain inactive.
+  public interrupt(token: Runtime.Types.ProcessToken, terminate?: boolean): Promise<void> {
+    return Promise.resolve();
   }
 
   protected async executeInternally(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/call_activity_handler.ts
+++ b/src/runtime/engine/flow_node_handler/call_activity_handler.ts
@@ -1,6 +1,5 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {
@@ -99,7 +98,7 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
 
     onSuspendToken.payload = callActivityResult;
     await this.persistOnResume(onSuspendToken);
-    await processTokenFacade.addResultForFlowNode(this.callActivity.id, callActivityResult);
+    processTokenFacade.addResultForFlowNode(this.callActivity.id, callActivityResult);
     await this.persistOnExit(onSuspendToken);
 
     return this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);
@@ -121,7 +120,7 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
     token.payload = processStartResponse.tokenPayload;
 
     await this.persistOnResume(token);
-    await processTokenFacade.addResultForFlowNode(this.callActivity.id, processStartResponse.tokenPayload);
+    processTokenFacade.addResultForFlowNode(this.callActivity.id, processStartResponse.tokenPayload);
     await this.persistOnExit(token);
 
     return this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
@@ -165,7 +164,7 @@ export class CallActivityHandler extends FlowNodeHandler<Model.Activities.CallAc
                                    token: Runtime.Types.ProcessToken ,
                                   ): Promise<ProcessStartResponsePayload> {
 
-    const tokenData: any = await processTokenFacade.getOldTokenFormat();
+    const tokenData: any = processTokenFacade.getOldTokenFormat();
 
     const processInstanceId: string = token.processInstanceId;
     const correlationId: string = token.correlationId;

--- a/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/exclusive_gateway_handler.ts
@@ -168,7 +168,7 @@ export class ExclusiveGatewayHandler extends FlowNodeHandler<Model.Gateways.Excl
   }
 
   private async executeCondition(condition: string, processTokenFacade: IProcessTokenFacade): Promise<boolean> {
-    const tokenData: any = await processTokenFacade.getOldTokenFormat();
+    const tokenData: any = processTokenFacade.getOldTokenFormat();
 
     try {
       const functionString: string = `return ${condition}`;

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -507,18 +507,17 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
    * Gets the FlowNodeInfo about the next FlowNode to execute after this
    * handler has finished.
    *
-   * @async
    * @param token              The current Processtoken.
    * @param processTokenFacade The ProcessTokenFacade to use with the next FlowNode.
    * @param processModelFacade The ProcessModelFacade to use with the next FlowNode.
    * @returns                  The NextFlowNodeInfo object for the next FlowNode
    *                           to run.
    */
-  protected async getNextFlowNodeInfo(token: Runtime.Types.ProcessToken,
-                                      processTokenFacade: IProcessTokenFacade,
-                                      processModelFacade: IProcessModelFacade,
-                                     ): Promise<NextFlowNodeInfo> {
-    const nextFlowNode: Model.Base.FlowNode = await processModelFacade.getNextFlowNodeFor(this.flowNode);
+  protected getNextFlowNodeInfo(token: Runtime.Types.ProcessToken,
+                                processTokenFacade: IProcessTokenFacade,
+                                processModelFacade: IProcessModelFacade,
+                               ): NextFlowNodeInfo {
+    const nextFlowNode: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.flowNode);
 
     return new NextFlowNodeInfo(nextFlowNode, token, processTokenFacade);
   }

--- a/src/runtime/engine/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler.ts
@@ -78,7 +78,7 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
     try {
       nextFlowNode = await this.executeInternally(token, processTokenFacade, processModelFacade, identity);
     } catch (error) {
-      await processTokenFacade.addResultForFlowNode(this.flowNode.id, error);
+      processTokenFacade.addResultForFlowNode(this.flowNode.id, error);
       throw error;
     }
 
@@ -104,7 +104,7 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
     try {
       nextFlowNode = await this.resumeInternally(flowNodeInstance, processTokenFacade, processModelFacade, identity);
     } catch (error) {
-      await processTokenFacade.addResultForFlowNode(this.flowNode.id, error);
+      processTokenFacade.addResultForFlowNode(this.flowNode.id, error);
       throw error;
     }
 
@@ -538,13 +538,13 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
                              processTokenFacade: IProcessTokenFacade,
                              processModelFacade: IProcessModelFacade): Promise<void> {
 
-    await processTokenFacade.evaluateMapperForFlowNode(this.flowNode);
+    processTokenFacade.evaluateMapperForFlowNode(this.flowNode);
 
     const nextSequenceFlow: Model.Types.SequenceFlow = processModelFacade.getSequenceFlowBetween(this.flowNode, nextFlowNode);
     if (!nextSequenceFlow) {
       return;
     }
 
-    await processTokenFacade.evaluateMapperForSequenceFlow(nextSequenceFlow);
+    processTokenFacade.evaluateMapperForSequenceFlow(nextSequenceFlow);
   }
 }

--- a/src/runtime/engine/flow_node_handler/flow_node_handler_interruptable.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler_interruptable.ts
@@ -25,10 +25,18 @@ implements IInterruptable {
     this._onInterruptedCallback = (): void => { };
   }
 
+  /**
+   * Gets the callback that gets called when an interrupt-command was received.
+   * This can be used by the derived handlers to perform handler-specific actions
+   * necessary for stopping its work cleanly.
+   */
   protected get onInterruptedCallback(): onInterruptionCallback {
     return this._onInterruptedCallback;
   }
 
+  /**
+   * Sets the callback that gets called when an interrupt-command was received.
+   */
   protected set onInterruptedCallback(value: onInterruptionCallback) {
     this._onInterruptedCallback = value;
   }

--- a/src/runtime/engine/flow_node_handler/flow_node_handler_interruptable.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler_interruptable.ts
@@ -11,8 +11,8 @@ import {
 import {FlowNodeHandler} from './flow_node_handler';
 
 export abstract class FlowNodeHandlerInterruptable<TFlowNode extends Model.Base.FlowNode>
-extends FlowNodeHandler<TFlowNode>
-implements IInterruptable {
+  extends FlowNodeHandler<TFlowNode>
+  implements IInterruptable {
 
   private _onInterruptedCallback: onInterruptionCallback;
 

--- a/src/runtime/engine/flow_node_handler/flow_node_handler_interruptable.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler_interruptable.ts
@@ -1,8 +1,8 @@
 import {ILoggingApi} from '@process-engine/logging_api_contracts';
 import {IMetricsApi} from '@process-engine/metrics_api_contracts';
 import {
-  IActivityHandler,
   IFlowNodeInstanceService,
+  IInterruptable,
   Model,
   onInterruptionCallback,
   Runtime,
@@ -10,9 +10,9 @@ import {
 
 import {FlowNodeHandler} from './flow_node_handler';
 
-export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode>
+export abstract class FlowNodeHandlerInterruptable<TFlowNode extends Model.Base.FlowNode>
 extends FlowNodeHandler<TFlowNode>
-implements IActivityHandler<TFlowNode> {
+implements IInterruptable {
 
   private _onInterruptedCallback: onInterruptionCallback;
 

--- a/src/runtime/engine/flow_node_handler/flow_node_handler_interruptible.ts
+++ b/src/runtime/engine/flow_node_handler/flow_node_handler_interruptible.ts
@@ -2,7 +2,7 @@ import {ILoggingApi} from '@process-engine/logging_api_contracts';
 import {IMetricsApi} from '@process-engine/metrics_api_contracts';
 import {
   IFlowNodeInstanceService,
-  IInterruptable,
+  IInterruptible,
   Model,
   onInterruptionCallback,
   Runtime,
@@ -10,9 +10,9 @@ import {
 
 import {FlowNodeHandler} from './flow_node_handler';
 
-export abstract class FlowNodeHandlerInterruptable<TFlowNode extends Model.Base.FlowNode>
+export abstract class FlowNodeHandlerInterruptible<TFlowNode extends Model.Base.FlowNode>
   extends FlowNodeHandler<TFlowNode>
-  implements IInterruptable {
+  implements IInterruptible {
 
   private _onInterruptedCallback: onInterruptionCallback;
 

--- a/src/runtime/engine/flow_node_handler/index.ts
+++ b/src/runtime/engine/flow_node_handler/index.ts
@@ -1,6 +1,6 @@
-export * from './activity_handler';
 export * from './flow_node_handler_factory';
 export * from './flow_node_handler';
+export * from './flow_node_handler_interruptable';
 export * from './end_event_handler';
 export * from './service_task_handler';
 export * from './script_task_handler';

--- a/src/runtime/engine/flow_node_handler/index.ts
+++ b/src/runtime/engine/flow_node_handler/index.ts
@@ -1,6 +1,6 @@
 export * from './flow_node_handler_factory';
 export * from './flow_node_handler';
-export * from './flow_node_handler_interruptable';
+export * from './flow_node_handler_interruptible';
 export * from './end_event_handler';
 export * from './service_task_handler';
 export * from './script_task_handler';

--- a/src/runtime/engine/flow_node_handler/index.ts
+++ b/src/runtime/engine/flow_node_handler/index.ts
@@ -1,3 +1,4 @@
+export * from './activity_handler';
 export * from './flow_node_handler_factory';
 export * from './flow_node_handler';
 export * from './end_event_handler';

--- a/src/runtime/engine/flow_node_handler/intermediate_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_catch_event_handler.ts
@@ -14,11 +14,11 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler} from './index';
+import {FlowNodeHandlerInterruptable} from './index';
 
-export class IntermediateCatchEventHandler extends FlowNodeHandler<Model.Events.IntermediateCatchEvent> {
+export class IntermediateCatchEventHandler extends FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent> {
 
-  private _childHandler: FlowNodeHandler<Model.Events.IntermediateCatchEvent>;
+  private _childHandler: FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent>;
   private _container: IContainer = undefined;
 
   constructor(container: IContainer,
@@ -35,18 +35,28 @@ export class IntermediateCatchEventHandler extends FlowNodeHandler<Model.Events.
     return this._childHandler.getInstanceId();
   }
 
-  private _getChildEventHandler(): FlowNodeHandler<Model.Events.IntermediateCatchEvent> {
+  public async interrupt(token: Runtime.Types.ProcessToken, terminate?: boolean): Promise<void> {
+    return this._childHandler.interrupt(token, terminate);
+  }
+
+  private _getChildEventHandler(): FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent> {
 
     if (this.flowNode.messageEventDefinition) {
-      return this._container.resolve<FlowNodeHandler<Model.Events.IntermediateCatchEvent>>('IntermediateMessageCatchEventHandler', [this.flowNode]);
+      return this
+        ._container
+        .resolve<FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent>>('IntermediateMessageCatchEventHandler', [this.flowNode]);
     }
 
     if (this.flowNode.signalEventDefinition) {
-      return this._container.resolve<FlowNodeHandler<Model.Events.IntermediateCatchEvent>>('IntermediateSignalCatchEventHandler', [this.flowNode]);
+      return this
+        ._container
+        .resolve<FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent>>('IntermediateSignalCatchEventHandler', [this.flowNode]);
     }
 
     if (this.flowNode.timerEventDefinition) {
-      return this._container.resolve<FlowNodeHandler<Model.Events.IntermediateCatchEvent>>('IntermediateTimerCatchEventHandler', [this.flowNode]);
+      return this
+        ._container
+        .resolve<FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent>>('IntermediateTimerCatchEventHandler', [this.flowNode]);
     }
 
     throw new InternalServerError(`The IntermediateCatchEventType used with FlowNode ${this.flowNode.id} is not supported!`);

--- a/src/runtime/engine/flow_node_handler/intermediate_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_catch_event_handler.ts
@@ -14,11 +14,11 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from './index';
+import {FlowNodeHandlerInterruptible} from './index';
 
-export class IntermediateCatchEventHandler extends FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent> {
+export class IntermediateCatchEventHandler extends FlowNodeHandlerInterruptible<Model.Events.IntermediateCatchEvent> {
 
-  private _childHandler: FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent>;
+  private _childHandler: FlowNodeHandlerInterruptible<Model.Events.IntermediateCatchEvent>;
   private _container: IContainer = undefined;
 
   constructor(container: IContainer,
@@ -39,24 +39,24 @@ export class IntermediateCatchEventHandler extends FlowNodeHandlerInterruptable<
     return this._childHandler.interrupt(token, terminate);
   }
 
-  private _getChildEventHandler(): FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent> {
+  private _getChildEventHandler(): FlowNodeHandlerInterruptible<Model.Events.IntermediateCatchEvent> {
 
     if (this.flowNode.messageEventDefinition) {
       return this
         ._container
-        .resolve<FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent>>('IntermediateMessageCatchEventHandler', [this.flowNode]);
+        .resolve<FlowNodeHandlerInterruptible<Model.Events.IntermediateCatchEvent>>('IntermediateMessageCatchEventHandler', [this.flowNode]);
     }
 
     if (this.flowNode.signalEventDefinition) {
       return this
         ._container
-        .resolve<FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent>>('IntermediateSignalCatchEventHandler', [this.flowNode]);
+        .resolve<FlowNodeHandlerInterruptible<Model.Events.IntermediateCatchEvent>>('IntermediateSignalCatchEventHandler', [this.flowNode]);
     }
 
     if (this.flowNode.timerEventDefinition) {
       return this
         ._container
-        .resolve<FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent>>('IntermediateTimerCatchEventHandler', [this.flowNode]);
+        .resolve<FlowNodeHandlerInterruptible<Model.Events.IntermediateCatchEvent>>('IntermediateTimerCatchEventHandler', [this.flowNode]);
     }
 
     throw new InternalServerError(`The IntermediateCatchEventType used with FlowNode ${this.flowNode.id} is not supported!`);

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -17,9 +17,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandlerInterruptible} from '../index';
 
-export class IntermediateMessageCatchEventHandler extends FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent> {
+export class IntermediateMessageCatchEventHandler extends FlowNodeHandlerInterruptible<Model.Events.IntermediateCatchEvent> {
 
   private _eventAggregator: IEventAggregator;
   private subscription: ISubscription;

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -99,7 +99,7 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandlerInterru
       processTokenFacade.addResultForFlowNode(this.messageCatchEvent.id, receivedMessage.currentToken);
       await this.persistOnExit(token);
 
-      const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+      const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
       return resolve(nextFlowNodeInfo);
     });

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_message_catch_event_handler.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
@@ -73,9 +72,9 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandlerInterru
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
-    const handlerPromise: Bluebird<any> = new Bluebird<any>(async(resolve: Function, reject: Function): Promise<void> => {
+    const handlerPromise: Promise<any> = new Promise<any>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      const messageSubscriptionPromise: Bluebird<MessageEventReachedMessage> = this._waitForMessage();
+      const messageSubscriptionPromise: Promise<MessageEventReachedMessage> = this._waitForMessage();
 
       this.onInterruptedCallback = (interruptionToken: Runtime.Types.ProcessToken): void => {
 
@@ -107,9 +106,9 @@ export class IntermediateMessageCatchEventHandler extends FlowNodeHandlerInterru
     return handlerPromise;
   }
 
-  private _waitForMessage(): Bluebird<MessageEventReachedMessage> {
+  private _waitForMessage(): Promise<MessageEventReachedMessage> {
 
-    return new Bluebird<MessageEventReachedMessage>((resolve: Function): void => {
+    return new Promise<MessageEventReachedMessage>((resolve: Function): void => {
 
       const messageEventName: string = eventAggregatorSettings.routePaths.messageEventReached
         .replace(eventAggregatorSettings.routeParams.messageReference, this.messageCatchEvent.messageEventDefinition.name);

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
@@ -73,9 +72,9 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandlerInterrup
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
-    const handlerPromise: Bluebird<any> = new Bluebird<any>(async(resolve: Function, reject: Function): Promise<void> => {
+    const handlerPromise: Promise<any> = new Promise<any>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      const signalSubscriptionPromise: Bluebird<SignalEventReachedMessage> = this._waitForSignal();
+      const signalSubscriptionPromise: Promise<SignalEventReachedMessage> = this._waitForSignal();
 
       this.onInterruptedCallback = (interruptionToken: Runtime.Types.ProcessToken): void => {
 
@@ -107,9 +106,9 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandlerInterrup
     return handlerPromise;
   }
 
-  private _waitForSignal(): Bluebird<SignalEventReachedMessage> {
+  private _waitForSignal(): Promise<SignalEventReachedMessage> {
 
-    return new Bluebird<SignalEventReachedMessage>((resolve: Function): void => {
+    return new Promise<SignalEventReachedMessage>((resolve: Function): void => {
 
       const signalEventName: string = eventAggregatorSettings.routePaths.signalEventReached
         .replace(eventAggregatorSettings.routeParams.signalReference, this.signalCatchEvent.signalEventDefinition.name);

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -17,9 +17,9 @@ import {
   SignalEventReachedMessage,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandlerInterruptible} from '../index';
 
-export class IntermediateSignalCatchEventHandler extends FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent> {
+export class IntermediateSignalCatchEventHandler extends FlowNodeHandlerInterruptible<Model.Events.IntermediateCatchEvent> {
 
   private _eventAggregator: IEventAggregator;
   private subscription: ISubscription;

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_signal_catch_event_handler.ts
@@ -99,7 +99,7 @@ export class IntermediateSignalCatchEventHandler extends FlowNodeHandlerInterrup
       processTokenFacade.addResultForFlowNode(this.signalCatchEvent.id, receivedMessage.currentToken);
       await this.persistOnExit(token);
 
-      const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+      const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
       return resolve(nextFlowNodeInfo);
     });

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -97,7 +97,7 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandlerInterrupt
         this.timerSubscription.dispose();
       }
 
-      const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+      const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
       return resolve(nextFlowNodeInfo);
     });

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -17,9 +17,9 @@ import {
   TimerDefinitionType,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandlerInterruptible} from '../index';
 
-export class IntermediateTimerCatchEventHandler extends FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent> {
+export class IntermediateTimerCatchEventHandler extends FlowNodeHandlerInterruptible<Model.Events.IntermediateCatchEvent> {
 
   private _timerFacade: ITimerFacade;
   private timerSubscription: ISubscription;

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {ISubscription} from '@essential-projects/event_aggregator_contracts';
@@ -73,9 +72,9 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandlerInterrupt
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
-    const handlerPromise: Bluebird<NextFlowNodeInfo> = new Bluebird<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
+    const handlerPromise: Promise<NextFlowNodeInfo> = new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      const timerPromise: Bluebird<void> = this._executeTimer(token, processTokenFacade, processModelFacade);
+      const timerPromise: Promise<void> = this._executeTimer(token, processTokenFacade, processModelFacade);
 
       this.onInterruptedCallback = (interruptionToken: Runtime.Types.ProcessToken): void => {
 
@@ -107,9 +106,9 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandlerInterrupt
 
   private _executeTimer(token: Runtime.Types.ProcessToken,
                         processTokenFacade: IProcessTokenFacade,
-                        processModelFacade: IProcessModelFacade): Bluebird<void> {
+                        processModelFacade: IProcessModelFacade): Promise<void> {
 
-    return new Bluebird<void>(async(resolve: Function, reject: Function): Promise<void> => {
+    return new Promise<void>(async(resolve: Function, reject: Function): Promise<void> => {
 
       const timerType: TimerDefinitionType = this._timerFacade.parseTimerDefinitionType(this.timerCatchEvent.timerEventDefinition);
       const timerValueFromDefinition: string = this._timerFacade.parseTimerDefinitionValue(this.timerCatchEvent.timerEventDefinition);

--- a/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/intermediate_event_handlers/intermediate_timer_catch_event_handler.ts
@@ -1,3 +1,4 @@
+import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {ISubscription} from '@essential-projects/event_aggregator_contracts';
@@ -16,11 +17,12 @@ import {
   TimerDefinitionType,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler} from '../index';
+import {FlowNodeHandlerInterruptable} from '../index';
 
-export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Events.IntermediateCatchEvent> {
+export class IntermediateTimerCatchEventHandler extends FlowNodeHandlerInterruptable<Model.Events.IntermediateCatchEvent> {
 
   private _timerFacade: ITimerFacade;
+  private timerSubscription: ISubscription;
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingService: ILoggingApi,
@@ -71,36 +73,67 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
-    return new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
+    const handlerPromise: Bluebird<NextFlowNodeInfo> = new Bluebird<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      let timerSubscription: ISubscription;
+      const timerPromise: Bluebird<void> = this._executeTimer(token, processTokenFacade, processModelFacade);
+
+      this.onInterruptedCallback = (interruptionToken: Runtime.Types.ProcessToken): void => {
+
+        processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, interruptionToken);
+
+        if (this.timerSubscription) {
+          this.timerSubscription.dispose();
+        }
+
+        timerPromise.cancel();
+        handlerPromise.cancel();
+
+        return;
+      };
+
+      await timerPromise;
+
+      if (this.timerSubscription) {
+        this.timerSubscription.dispose();
+      }
+
+      const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+
+      return resolve(nextFlowNodeInfo);
+    });
+
+    return handlerPromise;
+  }
+
+  private _executeTimer(token: Runtime.Types.ProcessToken,
+                        processTokenFacade: IProcessTokenFacade,
+                        processModelFacade: IProcessModelFacade): Bluebird<void> {
+
+    return new Bluebird<void>(async(resolve: Function, reject: Function): Promise<void> => {
 
       const timerType: TimerDefinitionType = this._timerFacade.parseTimerDefinitionType(this.timerCatchEvent.timerEventDefinition);
       const timerValueFromDefinition: string = this._timerFacade.parseTimerDefinitionValue(this.timerCatchEvent.timerEventDefinition);
-      const timerValue: string = await this._executeTimerExpressionIfNeeded(timerValueFromDefinition, processTokenFacade);
+      const timerValue: string = this._executeTimerExpressionIfNeeded(timerValueFromDefinition, processTokenFacade);
 
-      const nextFlowNodeInfo: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.timerCatchEvent);
+      const timerElapsed: any = (): void => {
 
-      const timerElapsed: any = async(): Promise<void> => {
-
-        await this.persistOnResume(token);
-
-        await processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, token.payload);
-
-        if (timerSubscription && timerType !== TimerDefinitionType.cycle) {
-          timerSubscription.dispose();
+        if (this.timerSubscription && timerType !== TimerDefinitionType.cycle) {
+          this.timerSubscription.dispose();
         }
 
-        await this.persistOnExit(token);
+        // if the timer elapsed before the decorated handler finished execution,
+        // the TimerBoundaryEvent will be used to determine the next FlowNode to execute
+        processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, token.payload);
 
-        resolve(new NextFlowNodeInfo(nextFlowNodeInfo, token, processTokenFacade));
+        const nextNodeAfterBoundaryEvent: Model.Base.FlowNode = processModelFacade.getNextFlowNodeFor(this.timerCatchEvent);
+        resolve(new NextFlowNodeInfo(nextNodeAfterBoundaryEvent, token, processTokenFacade));
       };
 
-      timerSubscription = this._timerFacade.initializeTimer(this.timerCatchEvent, timerType, timerValue, timerElapsed);
+      this.timerSubscription = this._timerFacade.initializeTimer(this.timerCatchEvent, timerType, timerValue, timerElapsed);
     });
   }
 
-  private async _executeTimerExpressionIfNeeded(timerExpression: string, processTokenFacade: IProcessTokenFacade): Promise<string> {
+  private _executeTimerExpressionIfNeeded(timerExpression: string, processTokenFacade: IProcessTokenFacade): string {
     const tokenVariableName: string = 'token';
     const isConstantTimerExpression: boolean = !timerExpression.includes(tokenVariableName);
 
@@ -108,7 +141,7 @@ export class IntermediateTimerCatchEventHandler extends FlowNodeHandler<Model.Ev
       return timerExpression;
     }
 
-    const tokenData: any = await processTokenFacade.getOldTokenFormat();
+    const tokenData: any = processTokenFacade.getOldTokenFormat();
 
     try {
       const functionString: string = `return ${timerExpression}`;

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -101,7 +101,7 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptable<Model.Activi
 
       this._sendManualTaskFinishedNotification(token);
 
-      const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+      const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
       return resolve(nextFlowNodeInfo);
     });

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -81,13 +81,10 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptable<Model.Activi
 
       const executionPromise: Bluebird<any> = this._waitForManualTaskResult(token);
 
-      this.onInterruptedCallback = (interruptionToken: Runtime.Types.ProcessToken): void => {
-
+      this.onInterruptedCallback = (): void => {
         if (this.manualTaskSubscription) {
           this.manualTaskSubscription.dispose();
         }
-
-        processTokenFacade.addResultForFlowNode(this.manualTask.id, interruptionToken.payload);
         executionPromise.cancel();
         handlerPromise.cancel();
 

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -91,7 +91,7 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptable<Model.Activi
         executionPromise.cancel();
         handlerPromise.cancel();
 
-        return resolve();
+        return;
       };
 
       const manualTaskResult: any = await executionPromise;
@@ -121,14 +121,14 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptable<Model.Activi
    *              creating the EventSubscription.
    * @returns     The recevied ManualTask result.
    */
-  private async _waitForManualTaskResult(token: Runtime.Types.ProcessToken): Promise<any> {
+  private _waitForManualTaskResult(token: Runtime.Types.ProcessToken): Bluebird<any> {
 
     return new Bluebird<any>(async(resolve: Function): Promise<void> => {
 
       const finishManualTaskEvent: string = this._getFinishManualTaskEventName(token.correlationId, token.processInstanceId);
 
       this.manualTaskSubscription =
-        this._eventAggregator.subscribeOnce(finishManualTaskEvent, async(message: FinishManualTaskMessage): Promise<void> => {
+        this._eventAggregator.subscribeOnce(finishManualTaskEvent, (message: FinishManualTaskMessage): void => {
 
           // An empty object is used, because ManualTasks do not yield results.
           const manualTaskResult: any = {};

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
@@ -77,9 +76,9 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
                                   processModelFacade: IProcessModelFacade,
                                  ): Promise<NextFlowNodeInfo> {
 
-    const handlerPromise: Bluebird<NextFlowNodeInfo> = new Bluebird<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
+    const handlerPromise: Promise<NextFlowNodeInfo> = new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      const executionPromise: Bluebird<any> = this._waitForManualTaskResult(token);
+      const executionPromise: Promise<any> = this._waitForManualTaskResult(token);
 
       this.onInterruptedCallback = (): void => {
         if (this.manualTaskSubscription) {
@@ -118,9 +117,9 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
    *              creating the EventSubscription.
    * @returns     The recevied ManualTask result.
    */
-  private _waitForManualTaskResult(token: Runtime.Types.ProcessToken): Bluebird<any> {
+  private _waitForManualTaskResult(token: Runtime.Types.ProcessToken): Promise<any> {
 
-    return new Bluebird<any>(async(resolve: Function): Promise<void> => {
+    return new Promise<any>(async(resolve: Function): Promise<void> => {
 
       const finishManualTaskEvent: string = this._getFinishManualTaskEventName(token.correlationId, token.processInstanceId);
 

--- a/src/runtime/engine/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/manual_task_handler.ts
@@ -19,9 +19,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from './index';
+import {FlowNodeHandlerInterruptible} from './index';
 
-export class ManualTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.ManualTask> {
+export class ManualTaskHandler extends FlowNodeHandlerInterruptible<Model.Activities.ManualTask> {
 
   private _eventAggregator: IEventAggregator;
 

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handler.ts
@@ -1,10 +1,9 @@
 import {IContainer} from 'addict-ioc';
-import * as moment from 'moment';
 
 import {UnprocessableEntityError} from '@essential-projects/errors_ts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
-import {ILoggingApi, LogLevel} from '@process-engine/logging_api_contracts';
+import {ILoggingApi} from '@process-engine/logging_api_contracts';
 import {IMetricsApi} from '@process-engine/metrics_api_contracts';
 import {
   IFlowNodeInstanceService,

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handler.ts
@@ -14,11 +14,11 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler} from './index';
+import {FlowNodeHandlerInterruptable} from './index';
 
-export class ParallelGatewayHandler extends FlowNodeHandler<Model.Gateways.ParallelGateway> {
+export class ParallelGatewayHandler extends FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway> {
 
-  private _childHandler: FlowNodeHandler<Model.Gateways.ParallelGateway>;
+  private _childHandler: FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway>;
   private _container: IContainer = undefined;
 
   constructor(container: IContainer,
@@ -36,13 +36,17 @@ export class ParallelGatewayHandler extends FlowNodeHandler<Model.Gateways.Paral
     return this._childHandler.getInstanceId();
   }
 
-  private _getChildHandler(): FlowNodeHandler<Model.Gateways.ParallelGateway> {
+  public async interrupt(token: Runtime.Types.ProcessToken, terminate?: boolean): Promise<void> {
+    return this._childHandler.interrupt(token, terminate);
+  }
+
+  private _getChildHandler(): FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway> {
 
     switch (this.flowNode.gatewayDirection) {
       case Model.Gateways.GatewayDirection.Converging:
-        return this._container.resolve<FlowNodeHandler<Model.Gateways.ParallelGateway>>('ParallelJoinGatewayHandler', [this.flowNode]);
+        return this._container.resolve<FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway>>('ParallelJoinGatewayHandler', [this.flowNode]);
       case Model.Gateways.GatewayDirection.Diverging:
-        return this._container.resolve<FlowNodeHandler<Model.Gateways.ParallelGateway>>('ParallelSplitGatewayHandler', [this.flowNode]);
+        return this._container.resolve<FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway>>('ParallelSplitGatewayHandler', [this.flowNode]);
       default:
         const unsupportedErrorMessage: string =
           `ParallelGateway ${this.flowNode.id} is neither a Split- nor a Join-Gateway! Mixed Gateways are NOT supported!`;

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handler.ts
@@ -14,11 +14,11 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from './index';
+import {FlowNodeHandler} from './index';
 
-export class ParallelGatewayHandler extends FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway> {
+export class ParallelGatewayHandler extends FlowNodeHandler<Model.Gateways.ParallelGateway> {
 
-  private _childHandler: FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway>;
+  private _childHandler: FlowNodeHandler<Model.Gateways.ParallelGateway>;
   private _container: IContainer = undefined;
 
   constructor(container: IContainer,
@@ -36,17 +36,13 @@ export class ParallelGatewayHandler extends FlowNodeHandlerInterruptable<Model.G
     return this._childHandler.getInstanceId();
   }
 
-  public async interrupt(token: Runtime.Types.ProcessToken, terminate?: boolean): Promise<void> {
-    return this._childHandler.interrupt(token, terminate);
-  }
-
-  private _getChildHandler(): FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway> {
+  private _getChildHandler(): FlowNodeHandler<Model.Gateways.ParallelGateway> {
 
     switch (this.flowNode.gatewayDirection) {
       case Model.Gateways.GatewayDirection.Converging:
-        return this._container.resolve<FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway>>('ParallelJoinGatewayHandler', [this.flowNode]);
+        return this._container.resolve<FlowNodeHandler<Model.Gateways.ParallelGateway>>('ParallelJoinGatewayHandler', [this.flowNode]);
       case Model.Gateways.GatewayDirection.Diverging:
-        return this._container.resolve<FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway>>('ParallelSplitGatewayHandler', [this.flowNode]);
+        return this._container.resolve<FlowNodeHandler<Model.Gateways.ParallelGateway>>('ParallelSplitGatewayHandler', [this.flowNode]);
       default:
         const unsupportedErrorMessage: string =
           `ParallelGateway ${this.flowNode.id} is neither a Split- nor a Join-Gateway! Mixed Gateways are NOT supported!`;

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
@@ -13,9 +13,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandler} from '../index';
 
-export class ParallelJoinGatewayHandler extends FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway> {
+export class ParallelJoinGatewayHandler extends FlowNodeHandler<Model.Gateways.ParallelGateway> {
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
@@ -41,7 +41,7 @@ export class ParallelJoinGatewayHandler extends FlowNodeHandler<Model.Gateways.P
                                   processModelFacade: IProcessModelFacade,
                                   identity: IIdentity): Promise<NextFlowNodeInfo> {
     await this.persistOnExit(token);
-    await processTokenFacade.addResultForFlowNode(this.flowNode.id, token.payload);
+    processTokenFacade.addResultForFlowNode(this.flowNode.id, token.payload);
 
     return this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
   }

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_join_gateway_handler.ts
@@ -13,9 +13,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler} from '../index';
+import {FlowNodeHandlerInterruptable} from '../index';
 
-export class ParallelJoinGatewayHandler extends FlowNodeHandler<Model.Gateways.ParallelGateway> {
+export class ParallelJoinGatewayHandler extends FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway> {
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import * as clone from 'clone';
 import {Logger} from 'loggerhythm';
 
@@ -21,9 +20,9 @@ import {
   TerminateEndEventReachedMessage,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandler} from '../index';
 
-export class ParallelSplitGatewayHandler extends FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway> {
+export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.ParallelGateway> {
 
   private _eventAggregator: IEventAggregator;
   private _flowNodeHandlerFactory: IFlowNodeHandlerFactory;

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
@@ -1,3 +1,4 @@
+import * as Bluebird from 'bluebird';
 import * as clone from 'clone';
 import {Logger} from 'loggerhythm';
 
@@ -20,9 +21,9 @@ import {
   TerminateEndEventReachedMessage,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler} from '../index';
+import {FlowNodeHandlerInterruptable} from '../index';
 
-export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.ParallelGateway> {
+export class ParallelSplitGatewayHandler extends FlowNodeHandlerInterruptable<Model.Gateways.ParallelGateway> {
 
   private _eventAggregator: IEventAggregator;
   private _flowNodeHandlerFactory: IFlowNodeHandlerFactory;

--- a/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
+++ b/src/runtime/engine/flow_node_handler/parallel_gateway_handlers/parallel_split_gateway_handler.ts
@@ -188,7 +188,7 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
     return outgoingSequenceFlows.map(async(outgoingSequenceFlow: Model.Types.SequenceFlow): Promise<NextFlowNodeInfo> => {
 
       // To have an isolated ProcessToken for each branch, we fork a new ProcessToken from the original one and use it during execution of this branch
-      const processTokenForBranch: IProcessTokenFacade = await processTokenFacade.getProcessTokenFacadeForParallelBranch();
+      const processTokenForBranch: IProcessTokenFacade = processTokenFacade.getProcessTokenFacadeForParallelBranch();
       const tokenForBranch: Runtime.Types.ProcessToken = processTokenFacade.createProcessToken(token.payload);
 
       const nextFlowNodeInBranch: Model.Base.FlowNode = processModelFacade.getFlowNodeById(outgoingSequenceFlow.targetRef);
@@ -250,7 +250,7 @@ export class ParallelSplitGatewayHandler extends FlowNodeHandler<Model.Gateways.
     return outgoingSequenceFlows.map(async(outgoingSequenceFlow: Model.Types.SequenceFlow): Promise<NextFlowNodeInfo> => {
 
       // To have an isolated ProcessToken for each branch, we fork a new ProcessToken from the original one and use it during execution of this branch
-      const processTokenForBranch: IProcessTokenFacade = await processTokenFacade.getProcessTokenFacadeForParallelBranch();
+      const processTokenForBranch: IProcessTokenFacade = processTokenFacade.getProcessTokenFacadeForParallelBranch();
       const tokenForBranch: Runtime.Types.ProcessToken = processTokenFacade.createProcessToken(token.payload);
 
       const firstFlowNodeInBranch: Model.Base.FlowNode = processModelFacade.getFlowNodeById(outgoingSequenceFlow.targetRef);

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -1,6 +1,5 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {ILoggingApi} from '@process-engine/logging_api_contracts';

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -16,9 +16,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from './index';
+import {FlowNodeHandlerInterruptible} from './index';
 
-export class ReceiveTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.ReceiveTask> {
+export class ReceiveTaskHandler extends FlowNodeHandlerInterruptible<Model.Activities.ReceiveTask> {
 
   private _eventAggregator: IEventAggregator;
   private messageSubscription: ISubscription;

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
@@ -62,9 +61,9 @@ export class ReceiveTaskHandler extends FlowNodeHandlerInterruptible<Model.Activ
                                   processTokenFacade: IProcessTokenFacade,
                                   processModelFacade: IProcessModelFacade): Promise<NextFlowNodeInfo> {
 
-    const handlerPromise: Bluebird<NextFlowNodeInfo> = new Bluebird<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
+    const handlerPromise: Promise<NextFlowNodeInfo> = new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      const executionPromise: Bluebird<MessageEventReachedMessage> = this._waitForMessage();
+      const executionPromise: Promise<MessageEventReachedMessage> = this._waitForMessage();
 
       this.onInterruptedCallback = (): void => {
         if (this.messageSubscription) {
@@ -100,7 +99,7 @@ export class ReceiveTaskHandler extends FlowNodeHandlerInterruptible<Model.Activ
    */
   private async _waitForMessage(): Promise<MessageEventReachedMessage> {
 
-    return new Bluebird<MessageEventReachedMessage>((resolve: Function): void => {
+    return new Promise<MessageEventReachedMessage>((resolve: Function): void => {
 
       const messageEventName: string = eventAggregatorSettings
         .routePaths

--- a/src/runtime/engine/flow_node_handler/receive_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/receive_task_handler.ts
@@ -84,7 +84,7 @@ export class ReceiveTaskHandler extends FlowNodeHandlerInterruptable<Model.Activ
       processTokenFacade.addResultForFlowNode(this.receiveTask.id, receivedMessage.currentToken);
       await this.persistOnExit(receivedMessage.currentToken);
 
-      const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+      const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
       return resolve(nextFlowNodeInfo);
     });

--- a/src/runtime/engine/flow_node_handler/script_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/script_task_handler.ts
@@ -14,9 +14,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from './index';
+import {FlowNodeHandlerInterruptible} from './index';
 
-export class ScriptTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.ScriptTask> {
+export class ScriptTaskHandler extends FlowNodeHandlerInterruptible<Model.Activities.ScriptTask> {
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,

--- a/src/runtime/engine/flow_node_handler/script_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/script_task_handler.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {IIdentity} from '@essential-projects/iam_contracts';
@@ -48,12 +47,12 @@ export class ScriptTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
                                   identity: IIdentity,
                                  ): Promise<NextFlowNodeInfo> {
 
-    const handlerPromise: Bluebird<any> = new Bluebird<any>(async(resolve: Function, reject: Function): Promise<void> => {
+    const handlerPromise: Promise<any> = new Promise<any>(async(resolve: Function, reject: Function): Promise<void> => {
 
       let result: any = {};
 
       try {
-        const executionPromise: Bluebird<any> = this._executeScriptTask(processTokenFacade, identity);
+        const executionPromise: Promise<any> = this._executeScriptTask(processTokenFacade, identity);
 
         this.onInterruptedCallback = (interruptionToken: Runtime.Types.ProcessToken): void => {
           processTokenFacade.addResultForFlowNode(this.scriptTask.id, interruptionToken.payload);
@@ -81,9 +80,9 @@ export class ScriptTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
     return handlerPromise;
   }
 
-  private _executeScriptTask(processTokenFacade: IProcessTokenFacade, identity: IIdentity): Bluebird<any> {
+  private _executeScriptTask(processTokenFacade: IProcessTokenFacade, identity: IIdentity): Promise<any> {
 
-    return new Bluebird<any>(async(resolve: Function, reject: Function, onCancel: Function): Promise<void> => {
+    return new Promise<any>(async(resolve: Function, reject: Function, onCancel: Function): Promise<void> => {
 
       const script: string = this.scriptTask.script;
 

--- a/src/runtime/engine/flow_node_handler/script_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/script_task_handler.ts
@@ -69,7 +69,7 @@ export class ScriptTaskHandler extends FlowNodeHandlerInterruptable<Model.Activi
         return reject(error);
       }
 
-      await processTokenFacade.addResultForFlowNode(this.scriptTask.id, result);
+      processTokenFacade.addResultForFlowNode(this.scriptTask.id, result);
       token.payload = result;
       await this.persistOnExit(token);
 
@@ -91,7 +91,7 @@ export class ScriptTaskHandler extends FlowNodeHandlerInterruptable<Model.Activi
         return undefined;
       }
 
-      const tokenData: any = await processTokenFacade.getOldTokenFormat();
+      const tokenData: any = processTokenFacade.getOldTokenFormat();
       let result: any;
 
       const scriptFunction: Function = new Function('token', 'identity', script);

--- a/src/runtime/engine/flow_node_handler/script_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/script_task_handler.ts
@@ -14,9 +14,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {ActivityHandler} from './index';
+import {FlowNodeHandlerInterruptable} from './index';
 
-export class ScriptTaskHandler extends ActivityHandler<Model.Activities.ScriptTask> {
+export class ScriptTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.ScriptTask> {
 
   constructor(flowNodeInstanceService: IFlowNodeInstanceService,
               loggingApiService: ILoggingApi,

--- a/src/runtime/engine/flow_node_handler/script_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/script_task_handler.ts
@@ -55,8 +55,8 @@ export class ScriptTaskHandler extends FlowNodeHandlerInterruptable<Model.Activi
       try {
         const executionPromise: Bluebird<any> = this._executeScriptTask(processTokenFacade, identity);
 
-        this.onInterruptedCallback = async(interruptionToken: Runtime.Types.ProcessToken): Promise<void> => {
-          await processTokenFacade.addResultForFlowNode(this.scriptTask.id, interruptionToken.payload);
+        this.onInterruptedCallback = (interruptionToken: Runtime.Types.ProcessToken): void => {
+          processTokenFacade.addResultForFlowNode(this.scriptTask.id, interruptionToken.payload);
           executionPromise.cancel();
           handlerPromise.cancel();
 

--- a/src/runtime/engine/flow_node_handler/script_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/script_task_handler.ts
@@ -73,7 +73,7 @@ export class ScriptTaskHandler extends FlowNodeHandlerInterruptable<Model.Activi
       token.payload = result;
       await this.persistOnExit(token);
 
-      const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+      const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
       return resolve(nextFlowNodeInfo);
     });

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
@@ -64,7 +63,7 @@ export class SendTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
                                   processModelFacade: IProcessModelFacade,
                                  ): Promise<NextFlowNodeInfo> {
 
-    const handlerPromise: Bluebird<NextFlowNodeInfo> = new Bluebird<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
+    const handlerPromise: Promise<NextFlowNodeInfo> = new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
       this.onInterruptedCallback = (): void => {
         if (this.responseSubscription) {

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -17,9 +17,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from './index';
+import {FlowNodeHandlerInterruptible} from './index';
 
-export class SendTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.SendTask> {
+export class SendTaskHandler extends FlowNodeHandlerInterruptible<Model.Activities.SendTask> {
 
   private _eventAggregator: IEventAggregator;
   private responseSubscription: ISubscription;

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -1,6 +1,5 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 

--- a/src/runtime/engine/flow_node_handler/send_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/send_task_handler.ts
@@ -80,7 +80,7 @@ export class SendTaskHandler extends FlowNodeHandlerInterruptable<Model.Activiti
         await this.persistOnResume(token);
         await this.persistOnExit(token);
 
-        const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+        const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
         return resolve(nextFlowNodeInfo);
       };

--- a/src/runtime/engine/flow_node_handler/service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handler.ts
@@ -13,11 +13,11 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler} from './index';
+import {ActivityHandler} from './index';
 
-export class ServiceTaskHandler extends FlowNodeHandler<Model.Activities.ServiceTask> {
+export class ServiceTaskHandler extends ActivityHandler<Model.Activities.ServiceTask> {
 
-  private _childHandler: FlowNodeHandler<Model.Activities.ServiceTask>;
+  private _childHandler: ActivityHandler<Model.Activities.ServiceTask>;
   private _container: IContainer = undefined;
 
   constructor(container: IContainer,
@@ -35,13 +35,17 @@ export class ServiceTaskHandler extends FlowNodeHandler<Model.Activities.Service
     return this._childHandler.getInstanceId();
   }
 
-  private _getChildHandler(): FlowNodeHandler<Model.Activities.ServiceTask> {
+  public async interrupt(token: Runtime.Types.ProcessToken, terminate?: boolean): Promise<void> {
+    return this._childHandler.interrupt(token, terminate);
+  }
+
+  private _getChildHandler(): ActivityHandler<Model.Activities.ServiceTask> {
 
     if (this.flowNode.type === Model.Activities.ServiceTaskType.external) {
-      return this._container.resolve<FlowNodeHandler<Model.Activities.ServiceTask>>('ExternalServiceTaskHandler', [this.flowNode]);
+      return this._container.resolve<ActivityHandler<Model.Activities.ServiceTask>>('ExternalServiceTaskHandler', [this.flowNode]);
     }
 
-    return this._container.resolve<FlowNodeHandler<Model.Activities.ServiceTask>>('InternalServiceTaskHandler', [this.flowNode]);
+    return this._container.resolve<ActivityHandler<Model.Activities.ServiceTask>>('InternalServiceTaskHandler', [this.flowNode]);
   }
 
   protected async executeInternally(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handler.ts
@@ -13,11 +13,11 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {ActivityHandler} from './index';
+import {FlowNodeHandlerInterruptable} from './index';
 
-export class ServiceTaskHandler extends ActivityHandler<Model.Activities.ServiceTask> {
+export class ServiceTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.ServiceTask> {
 
-  private _childHandler: ActivityHandler<Model.Activities.ServiceTask>;
+  private _childHandler: FlowNodeHandlerInterruptable<Model.Activities.ServiceTask>;
   private _container: IContainer = undefined;
 
   constructor(container: IContainer,
@@ -39,13 +39,13 @@ export class ServiceTaskHandler extends ActivityHandler<Model.Activities.Service
     return this._childHandler.interrupt(token, terminate);
   }
 
-  private _getChildHandler(): ActivityHandler<Model.Activities.ServiceTask> {
+  private _getChildHandler(): FlowNodeHandlerInterruptable<Model.Activities.ServiceTask> {
 
     if (this.flowNode.type === Model.Activities.ServiceTaskType.external) {
-      return this._container.resolve<ActivityHandler<Model.Activities.ServiceTask>>('ExternalServiceTaskHandler', [this.flowNode]);
+      return this._container.resolve<FlowNodeHandlerInterruptable<Model.Activities.ServiceTask>>('ExternalServiceTaskHandler', [this.flowNode]);
     }
 
-    return this._container.resolve<ActivityHandler<Model.Activities.ServiceTask>>('InternalServiceTaskHandler', [this.flowNode]);
+    return this._container.resolve<FlowNodeHandlerInterruptable<Model.Activities.ServiceTask>>('InternalServiceTaskHandler', [this.flowNode]);
   }
 
   protected async executeInternally(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handler.ts
@@ -13,11 +13,11 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from './index';
+import {FlowNodeHandlerInterruptible} from './index';
 
-export class ServiceTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.ServiceTask> {
+export class ServiceTaskHandler extends FlowNodeHandlerInterruptible<Model.Activities.ServiceTask> {
 
-  private _childHandler: FlowNodeHandlerInterruptable<Model.Activities.ServiceTask>;
+  private _childHandler: FlowNodeHandlerInterruptible<Model.Activities.ServiceTask>;
   private _container: IContainer = undefined;
 
   constructor(container: IContainer,
@@ -39,13 +39,13 @@ export class ServiceTaskHandler extends FlowNodeHandlerInterruptable<Model.Activ
     return this._childHandler.interrupt(token, terminate);
   }
 
-  private _getChildHandler(): FlowNodeHandlerInterruptable<Model.Activities.ServiceTask> {
+  private _getChildHandler(): FlowNodeHandlerInterruptible<Model.Activities.ServiceTask> {
 
     if (this.flowNode.type === Model.Activities.ServiceTaskType.external) {
-      return this._container.resolve<FlowNodeHandlerInterruptable<Model.Activities.ServiceTask>>('ExternalServiceTaskHandler', [this.flowNode]);
+      return this._container.resolve<FlowNodeHandlerInterruptible<Model.Activities.ServiceTask>>('ExternalServiceTaskHandler', [this.flowNode]);
     }
 
-    return this._container.resolve<FlowNodeHandlerInterruptable<Model.Activities.ServiceTask>>('InternalServiceTaskHandler', [this.flowNode]);
+    return this._container.resolve<FlowNodeHandlerInterruptible<Model.Activities.ServiceTask>>('InternalServiceTaskHandler', [this.flowNode]);
   }
 
   protected async executeInternally(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -1,3 +1,4 @@
+import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
@@ -15,12 +16,14 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandler} from '../index';
+import {FlowNodeHandlerInterruptable} from '../index';
 
-export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities.ServiceTask> {
+export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.ServiceTask> {
 
   private _eventAggregator: IEventAggregator;
   private _externalTaskRepository: IExternalTaskRepository;
+
+  private externalTaskSubscription: ISubscription;
 
   constructor(eventAggregator: IEventAggregator,
               externalTaskRepository: IExternalTaskRepository,
@@ -61,14 +64,18 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
     identity: IIdentity,
   ): Promise<NextFlowNodeInfo> {
 
-    return new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
+    const resumerPromise: Bluebird<NextFlowNodeInfo> = new Bluebird<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
       const externalTask: ExternalTask<any> = await this._getExternalTaskForFlowNodeInstance(flowNodeInstance);
 
+      let externalTaskExecutorPromise: Bluebird<any>;
+
       const noMatchingExteralTaskExists: boolean = !externalTask;
       if (noMatchingExteralTaskExists) {
-        // No ExternalTask has been created yet. We can just execute the normal handler method chain.
-        const result: any = await this._executeExternalServiceTask(onSuspendToken, processTokenFacade, identity);
+        // No ExternalTask has been created yet. We can just execute the normal handler.
+        externalTaskExecutorPromise = this._executeExternalServiceTask(onSuspendToken, processTokenFacade, identity);
+
+        const result: any = await externalTaskExecutorPromise;
 
         processTokenFacade.addResultForFlowNode(this.serviceTask.id, result);
         onSuspendToken.payload = result;
@@ -80,7 +87,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
       }
 
       // Callback for processing an ExternalTask result.
-      const processExternalTaskResult: Function = async(error: Error, result: any): Promise<void> => {
+      let processExternalTaskResult: Function = async(error: Error, result: any): Promise<void> => {
 
         if (error) {
           this.logger.error(`External processing of ServiceTask failed!`, error);
@@ -100,6 +107,22 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
         resolve(nextFlowNode);
       };
 
+      this.onInterruptedCallback = (): void => {
+
+        if (this.externalTaskSubscription) {
+          this.externalTaskSubscription.dispose();
+        }
+
+        if (externalTaskExecutorPromise) {
+          externalTaskExecutorPromise.cancel();
+        }
+        resumerPromise.cancel();
+
+        processExternalTaskResult = (): void => { return; };
+
+        return;
+      };
+
       const externalTaskIsAlreadyFinished: boolean = externalTask.state === ExternalTaskState.finished;
       if (externalTaskIsAlreadyFinished) {
         // The external worker has already finished processing the ExternalTask
@@ -112,6 +135,8 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
         this._waitForExternalTaskResult(processExternalTaskResult);
       }
     });
+
+    return resumerPromise;
   }
 
   protected async _executeHandler(
@@ -121,16 +146,37 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
     identity: IIdentity,
   ): Promise<NextFlowNodeInfo> {
 
-    this.logger.verbose('Executing external ServiceTask');
-    await this.persistOnSuspend(token);
-    const result: any = await this._executeExternalServiceTask(token, processTokenFacade, identity);
+    const handlerPromise: Bluebird<NextFlowNodeInfo> = new Bluebird<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
-    processTokenFacade.addResultForFlowNode(this.serviceTask.id, result);
-    token.payload = result;
+      this.logger.verbose('Executing external ServiceTask');
+      await this.persistOnSuspend(token);
+      const externalTaskExecutorPromise: Bluebird<any> = this._executeExternalServiceTask(token, processTokenFacade, identity);
 
-    await this.persistOnExit(token);
+      this.onInterruptedCallback = (): void => {
 
-    return this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+        if (this.externalTaskSubscription) {
+          this.externalTaskSubscription.dispose();
+        }
+
+        externalTaskExecutorPromise.cancel();
+        handlerPromise.cancel();
+
+        return;
+      };
+
+      const result: any = await externalTaskExecutorPromise;
+
+      processTokenFacade.addResultForFlowNode(this.serviceTask.id, result);
+      token.payload = result;
+
+      await this.persistOnExit(token);
+
+      const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+
+      return resolve(nextFlowNodeInfo);
+    });
+
+    return handlerPromise;
   }
 
   /**
@@ -151,7 +197,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
     identity: IIdentity,
   ): Promise<any> {
 
-    return new Promise(async(resolve: Function, reject: Function): Promise<any> => {
+    return new Bluebird<any>(async(resolve: Function, reject: Function): Promise<any> => {
 
       const externalTaskFinishedCallback: Function = async(error: Error, result: any): Promise<void> => {
 
@@ -193,14 +239,14 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
 
     const messageReceivedCallback: Function = async(message: any): Promise<void> => {
 
-      if (subscription) {
-        subscription.dispose();
+      if (this.externalTaskSubscription) {
+        this.externalTaskSubscription.dispose();
       }
 
       resolveFunc(message.error, message.result);
     };
 
-    const subscription: ISubscription = this._eventAggregator.subscribeOnce(externalTaskFinishedEventName, messageReceivedCallback);
+    this.externalTaskSubscription = this._eventAggregator.subscribeOnce(externalTaskFinishedEventName, messageReceivedCallback);
   }
 
   /**
@@ -215,7 +261,6 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
   private async _getExternalTaskForFlowNodeInstance(flowNodeInstance: Runtime.Types.FlowNodeInstance): Promise<ExternalTask<any>> {
 
     try {
-
       const matchingExternalTask: ExternalTask<any> =
         await this._externalTaskRepository.getByInstanceIds(flowNodeInstance.correlationId, flowNodeInstance.processInstanceId, flowNodeInstance.id);
 

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -16,9 +16,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandlerInterruptible} from '../index';
 
-export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.ServiceTask> {
+export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Model.Activities.ServiceTask> {
 
   private _eventAggregator: IEventAggregator;
   private _externalTaskRepository: IExternalTaskRepository;

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
@@ -64,11 +63,11 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
     identity: IIdentity,
   ): Promise<NextFlowNodeInfo> {
 
-    const resumerPromise: Bluebird<NextFlowNodeInfo> = new Bluebird<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
+    const resumerPromise: Promise<NextFlowNodeInfo> = new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
       const externalTask: ExternalTask<any> = await this._getExternalTaskForFlowNodeInstance(flowNodeInstance);
 
-      let externalTaskExecutorPromise: Bluebird<any>;
+      let externalTaskExecutorPromise: Promise<any>;
 
       const noMatchingExteralTaskExists: boolean = !externalTask;
       if (noMatchingExteralTaskExists) {
@@ -146,11 +145,11 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
     identity: IIdentity,
   ): Promise<NextFlowNodeInfo> {
 
-    const handlerPromise: Bluebird<NextFlowNodeInfo> = new Bluebird<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
+    const handlerPromise: Promise<NextFlowNodeInfo> = new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
       this.logger.verbose('Executing external ServiceTask');
       await this.persistOnSuspend(token);
-      const externalTaskExecutorPromise: Bluebird<any> = this._executeExternalServiceTask(token, processTokenFacade, identity);
+      const externalTaskExecutorPromise: Promise<any> = this._executeExternalServiceTask(token, processTokenFacade, identity);
 
       this.onInterruptedCallback = (): void => {
 
@@ -197,7 +196,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
     identity: IIdentity,
   ): Promise<any> {
 
-    return new Bluebird<any>(async(resolve: Function, reject: Function): Promise<any> => {
+    return new Promise<any>(async(resolve: Function, reject: Function): Promise<any> => {
 
       const externalTaskFinishedCallback: Function = async(error: Error, result: any): Promise<void> => {
 

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -81,7 +81,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
         onSuspendToken.payload = result;
         await this.persistOnExit(onSuspendToken);
 
-        const nextFlowNode: NextFlowNodeInfo = await this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);
+        const nextFlowNode: NextFlowNodeInfo = this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);
 
         return resolve(nextFlowNode);
       }
@@ -103,7 +103,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
         processTokenFacade.addResultForFlowNode(this.serviceTask.id, onSuspendToken.payload);
         await this.persistOnExit(onSuspendToken);
 
-        const nextFlowNode: NextFlowNodeInfo = await this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);
+        const nextFlowNode: NextFlowNodeInfo = this.getNextFlowNodeInfo(onSuspendToken, processTokenFacade, processModelFacade);
         resolve(nextFlowNode);
       };
 
@@ -171,7 +171,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
 
       await this.persistOnExit(token);
 
-      const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+      const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
       return resolve(nextFlowNodeInfo);
     });

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -1,6 +1,5 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
@@ -24,11 +23,11 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
   private _externalTaskRepository: IExternalTaskRepository;
 
   constructor(eventAggregator: IEventAggregator,
-    externalTaskRepository: IExternalTaskRepository,
-    flowNodeInstanceService: IFlowNodeInstanceService,
-    loggingApiService: ILoggingApi,
-    metricsService: IMetricsApi,
-    serviceTaskModel: Model.Activities.ServiceTask) {
+              externalTaskRepository: IExternalTaskRepository,
+              flowNodeInstanceService: IFlowNodeInstanceService,
+              loggingApiService: ILoggingApi,
+              metricsService: IMetricsApi,
+              serviceTaskModel: Model.Activities.ServiceTask) {
 
     super(flowNodeInstanceService, loggingApiService, metricsService, serviceTaskModel);
 
@@ -41,7 +40,8 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
     return super.flowNode;
   }
 
-  protected async executeInternally(token: Runtime.Types.ProcessToken,
+  protected async executeInternally(
+    token: Runtime.Types.ProcessToken,
     processTokenFacade: IProcessTokenFacade,
     processModelFacade: IProcessModelFacade,
     identity: IIdentity,
@@ -53,14 +53,15 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
     return this._executeHandler(token, processTokenFacade, processModelFacade, identity);
   }
 
-  protected async _continueAfterSuspend(flowNodeInstance: Runtime.Types.FlowNodeInstance,
+  protected async _continueAfterSuspend(
+    flowNodeInstance: Runtime.Types.FlowNodeInstance,
     onSuspendToken: Runtime.Types.ProcessToken,
     processTokenFacade: IProcessTokenFacade,
     processModelFacade: IProcessModelFacade,
     identity: IIdentity,
   ): Promise<NextFlowNodeInfo> {
 
-    return new Promise<NextFlowNodeInfo>(async (resolve: Function, reject: Function): Promise<void> => {
+    return new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
       const externalTask: ExternalTask<any> = await this._getExternalTaskForFlowNodeInstance(flowNodeInstance);
 
@@ -79,7 +80,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
       }
 
       // Callback for processing an ExternalTask result.
-      const processExternalTaskResult: Function = async (error: Error, result: any): Promise<void> => {
+      const processExternalTaskResult: Function = async(error: Error, result: any): Promise<void> => {
 
         if (error) {
           this.logger.error(`External processing of ServiceTask failed!`, error);
@@ -113,7 +114,8 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
     });
   }
 
-  protected async _executeHandler(token: Runtime.Types.ProcessToken,
+  protected async _executeHandler(
+    token: Runtime.Types.ProcessToken,
     processTokenFacade: IProcessTokenFacade,
     processModelFacade: IProcessModelFacade,
     identity: IIdentity,
@@ -143,14 +145,15 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
    * @param   identity           The identity that started the ProcessInstance.
    * @returns                    The ServiceTask's result.
    */
-  private async _executeExternalServiceTask(token: Runtime.Types.ProcessToken,
+  private async _executeExternalServiceTask(
+    token: Runtime.Types.ProcessToken,
     processTokenFacade: IProcessTokenFacade,
     identity: IIdentity,
   ): Promise<any> {
 
-    return new Promise(async (resolve: Function, reject: Function): Promise<any> => {
+    return new Promise(async(resolve: Function, reject: Function): Promise<any> => {
 
-      const externalTaskFinishedCallback: Function = async (error: Error, result: any): Promise<void> => {
+      const externalTaskFinishedCallback: Function = async(error: Error, result: any): Promise<void> => {
 
         if (error) {
           this.logger.error(`External processing of ServiceTask failed!`, error);
@@ -169,7 +172,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
 
       this._waitForExternalTaskResult(externalTaskFinishedCallback);
 
-      const tokenHistory: any = await processTokenFacade.getOldTokenFormat();
+      const tokenHistory: any = processTokenFacade.getOldTokenFormat();
       const payload: any = this._getServiceTaskPayload(token, tokenHistory, identity);
 
       await this._createExternalTask(token, payload);
@@ -188,7 +191,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandler<Model.Activities
 
     const externalTaskFinishedEventName: string = `/externaltask/flownodeinstance/${this.flowNodeInstanceId}/finished`;
 
-    const messageReceivedCallback: Function = async (message: any): Promise<void> => {
+    const messageReceivedCallback: Function = async(message: any): Promise<void> => {
 
       if (subscription) {
         subscription.dispose();

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -58,8 +58,6 @@ export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
 
     const handlerPromise: Bluebird<any> = new Bluebird<any>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      let nextFlowNodeInfo: NextFlowNodeInfo;
-
       const serviceTaskHasNoInvocation: boolean = this.serviceTask.invocation === undefined;
       if (serviceTaskHasNoInvocation) {
         this.logger.verbose('ServiceTask has no invocation. Skipping execution.');
@@ -67,7 +65,9 @@ export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
         processTokenFacade.addResultForFlowNode(this.serviceTask.id, {});
         token.payload = {};
 
-        nextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+        await this.persistOnExit(token);
+
+        const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
         return resolve(nextFlowNodeInfo);
       }
@@ -91,7 +91,7 @@ export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
 
         await this.persistOnExit(token);
 
-        nextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+        const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
         return resolve(nextFlowNodeInfo);
       } catch (error) {

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -74,8 +74,7 @@ export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
 
       const executionPromise: Bluebird<any> = this._executeInternalServiceTask(token, processTokenFacade, identity);
 
-      this.onInterruptedCallback = (interruptionToken: Runtime.Types.ProcessToken): void => {
-        processTokenFacade.addResultForFlowNode(this.serviceTask.id, interruptionToken.payload);
+      this.onInterruptedCallback = (): void => {
         executionPromise.cancel();
         handlerPromise.cancel();
 

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -16,9 +16,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {ActivityHandler} from '../index';
+import {FlowNodeHandlerInterruptable} from '../index';
 
-export class InternalServiceTaskHandler extends ActivityHandler<Model.Activities.ServiceTask> {
+export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.ServiceTask> {
 
   private _container: IContainer;
 

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -75,7 +75,7 @@ export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
       const executionPromise: Bluebird<any> = this._executeInternalServiceTask(token, processTokenFacade, identity);
 
       this.onInterruptedCallback = async(interruptionToken: Runtime.Types.ProcessToken): Promise<void> => {
-        await processTokenFacade.addResultForFlowNode(this.serviceTask.id, interruptionToken.payload);
+        processTokenFacade.addResultForFlowNode(this.serviceTask.id, interruptionToken.payload);
         executionPromise.cancel();
         handlerPromise.cancel();
 
@@ -131,7 +131,7 @@ export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
         throw new UnprocessableEntityError(notSupportedErrorMessage);
       }
 
-      const tokenData: any = await processTokenFacade.getOldTokenFormat();
+      const tokenData: any = processTokenFacade.getOldTokenFormat();
 
       const invocation: Model.Activities.MethodInvocation = this.serviceTask.invocation as Model.Activities.MethodInvocation;
 

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -74,7 +74,7 @@ export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
 
       const executionPromise: Bluebird<any> = this._executeInternalServiceTask(token, processTokenFacade, identity);
 
-      this.onInterruptedCallback = async(interruptionToken: Runtime.Types.ProcessToken): Promise<void> => {
+      this.onInterruptedCallback = (interruptionToken: Runtime.Types.ProcessToken): void => {
         processTokenFacade.addResultForFlowNode(this.serviceTask.id, interruptionToken.payload);
         executionPromise.cancel();
         handlerPromise.cancel();

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -16,9 +16,9 @@ import {
   Runtime,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from '../index';
+import {FlowNodeHandlerInterruptible} from '../index';
 
-export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.ServiceTask> {
+export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Model.Activities.ServiceTask> {
 
   private _container: IContainer;
 

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -76,7 +76,6 @@ export class InternalServiceTaskHandler extends ActivityHandler<Model.Activities
       const executionPromise: Bluebird<any> = this._executeInternalServiceTask(token, processTokenFacade, identity);
 
       this.onInterruptedCallback = async(interruptionToken: Runtime.Types.ProcessToken): Promise<void> => {
-        // tslint:disable:no-console
         await processTokenFacade.addResultForFlowNode(this.serviceTask.id, interruptionToken.payload);
         executionPromise.cancel();
         handlerPromise.cancel();

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -1,5 +1,4 @@
 import {IContainer} from 'addict-ioc';
-import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {UnprocessableEntityError} from '@essential-projects/errors_ts';
@@ -70,9 +69,9 @@ export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
       return nextFlowNodeInfo;
     }
 
-    const handlerPromise: Bluebird<any> = new Bluebird<any>(async(resolve: Function, reject: Function): Promise<void> => {
+    const handlerPromise: Promise<any> = new Promise<any>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      const executionPromise: Bluebird<any> = this._executeInternalServiceTask(token, processTokenFacade, identity);
+      const executionPromise: Promise<any> = this._executeInternalServiceTask(token, processTokenFacade, identity);
 
       this.onInterruptedCallback = (): void => {
         executionPromise.cancel();
@@ -117,9 +116,9 @@ export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
   private _executeInternalServiceTask(token: Runtime.Types.ProcessToken,
                                       processTokenFacade: IProcessTokenFacade,
                                       identity: IIdentity,
-                                     ): Bluebird<any> {
+                                     ): Promise<any> {
 
-    return new Bluebird<any>(async(resolve: Function, reject: Function, onCancel: Function): Promise<void> => {
+    return new Promise<any>(async(resolve: Function, reject: Function, onCancel: Function): Promise<void> => {
 
       const isMethodInvocation: boolean = this.serviceTask.invocation instanceof Model.Activities.MethodInvocation;
 

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/internal_service_task_handler.ts
@@ -65,7 +65,7 @@ export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
 
       await this.persistOnExit(token);
 
-      const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+      const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
       return nextFlowNodeInfo;
     }
@@ -90,7 +90,7 @@ export class InternalServiceTaskHandler extends FlowNodeHandlerInterruptable<Mod
 
         await this.persistOnExit(token);
 
-        const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+        const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
         return resolve(nextFlowNodeInfo);
       } catch (error) {

--- a/src/runtime/engine/flow_node_handler/start_event_handler.ts
+++ b/src/runtime/engine/flow_node_handler/start_event_handler.ts
@@ -1,6 +1,5 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -21,9 +21,9 @@ import {
 } from '@process-engine/process_engine_contracts';
 
 import {ProcessTokenFacade} from '../process_token_facade';
-import {FlowNodeHandler} from './index';
+import {FlowNodeHandlerInterruptible} from './index';
 
-export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProcess> {
+export class SubProcessHandler extends FlowNodeHandlerInterruptible<Model.Activities.SubProcess> {
 
   private _eventAggregator: IEventAggregator;
   private _flowNodeHandlerFactory: IFlowNodeHandlerFactory;
@@ -44,6 +44,11 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
 
   private get subProcess(): Model.Activities.SubProcess {
     return super.flowNode;
+  }
+
+  // TODO: We can't interrupt a Subprocess yet, so this will remain inactive.
+  public interrupt(token: Runtime.Types.ProcessToken, terminate?: boolean): Promise<void> {
+    return Promise.resolve();
   }
 
   protected async executeInternally(token: Runtime.Types.ProcessToken,

--- a/src/runtime/engine/flow_node_handler/sub_process_handler.ts
+++ b/src/runtime/engine/flow_node_handler/sub_process_handler.ts
@@ -141,7 +141,7 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
 
     const subProcessInstanceId: string = uuid.v4();
 
-    const currentResults: any = await processTokenFacade.getAllResults();
+    const currentResults: any = processTokenFacade.getAllResults();
 
     const subProcessTokenFacade: IProcessTokenFacade =
       new ProcessTokenFacade(subProcessInstanceId, this.subProcess.id, currentProcessToken.correlationId, identity);
@@ -213,7 +213,7 @@ export class SubProcessHandler extends FlowNodeHandler<Model.Activities.SubProce
     const subProcessStartEvents: Array<Model.Events.StartEvent> = subProcessModelFacade.getStartEvents();
     const subProcessStartEvent: Model.Events.StartEvent = subProcessStartEvents[0];
 
-    const currentResults: any = await processTokenFacade.getAllResults();
+    const currentResults: any = processTokenFacade.getAllResults();
 
     const subProcessInstanceId: string = flowNodeInstancesForSubprocess[0].processInstanceId;
 

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -19,9 +19,9 @@ import {
   UserTaskReachedMessage,
 } from '@process-engine/process_engine_contracts';
 
-import {FlowNodeHandlerInterruptable} from './index';
+import {FlowNodeHandlerInterruptible} from './index';
 
-export class UserTaskHandler extends FlowNodeHandlerInterruptable<Model.Activities.UserTask> {
+export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activities.UserTask> {
 
   private _eventAggregator: IEventAggregator;
 

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -100,7 +100,7 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptable<Model.Activiti
       await this.persistOnExit(token);
       this._sendUserTaskFinishedNotification(token);
 
-      const nextFlowNodeInfo: NextFlowNodeInfo = await this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
+      const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
       return resolve(nextFlowNodeInfo);
     });

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -118,7 +118,7 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptable<Model.Activiti
    *              creating the EventSubscription.
    * @returns     The recevied UserTask result.
    */
-  private async _waitForUserTaskResult(token: Runtime.Types.ProcessToken): Promise<any> {
+  private _waitForUserTaskResult(token: Runtime.Types.ProcessToken): Bluebird<any> {
 
     return new Bluebird<any>(async(resolve: Function): Promise<void> => {
 

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import {Logger} from 'loggerhythm';
 
 import {IEventAggregator, ISubscription} from '@essential-projects/event_aggregator_contracts';
@@ -77,9 +76,9 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
                                   processModelFacade: IProcessModelFacade,
                                  ): Promise<NextFlowNodeInfo> {
 
-    const handlerPromise: Bluebird<NextFlowNodeInfo> = new Bluebird<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
+    const handlerPromise: Promise<NextFlowNodeInfo> = new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      const executionPromise: Bluebird<any> = this._waitForUserTaskResult(token);
+      const executionPromise: Promise<any> = this._waitForUserTaskResult(token);
 
       this.onInterruptedCallback = (): void => {
         if (this.userTaskSubscription) {
@@ -118,9 +117,9 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
    *              creating the EventSubscription.
    * @returns     The recevied UserTask result.
    */
-  private _waitForUserTaskResult(token: Runtime.Types.ProcessToken): Bluebird<any> {
+  private _waitForUserTaskResult(token: Runtime.Types.ProcessToken): Promise<any> {
 
-    return new Bluebird<any>(async(resolve: Function): Promise<void> => {
+    return new Promise<any>(async(resolve: Function): Promise<void> => {
 
       const finishUserTaskEvent: string = this._getFinishUserTaskEventName(token.correlationId, token.processInstanceId);
 

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -81,13 +81,10 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptable<Model.Activiti
 
       const executionPromise: Bluebird<any> = this._waitForUserTaskResult(token);
 
-      this.onInterruptedCallback = (interruptionToken: Runtime.Types.ProcessToken): void => {
-
+      this.onInterruptedCallback = (): void => {
         if (this.userTaskSubscription) {
           this.userTaskSubscription.dispose();
         }
-
-        processTokenFacade.addResultForFlowNode(this.userTask.id, interruptionToken.payload);
         executionPromise.cancel();
         handlerPromise.cancel();
 

--- a/src/runtime/engine/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/user_task_handler.ts
@@ -91,7 +91,7 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptable<Model.Activiti
         executionPromise.cancel();
         handlerPromise.cancel();
 
-        return resolve();
+        return;
       };
 
       const userTaskResult: any = await executionPromise;

--- a/src/runtime/engine/process_token_facade.ts
+++ b/src/runtime/engine/process_token_facade.ts
@@ -30,8 +30,8 @@ export class ProcessTokenFacade implements IProcessTokenFacade {
     return this._identity;
   }
 
-  public async getAllResults(): Promise<Array<IProcessTokenResult>> {
-    return Promise.resolve(this.processTokenResults);
+  public getAllResults(): Array<IProcessTokenResult> {
+    return this.processTokenResults;
   }
 
   public createProcessToken(payload?: any): Runtime.Types.ProcessToken {
@@ -46,7 +46,7 @@ export class ProcessTokenFacade implements IProcessTokenFacade {
     return token;
   }
 
-  public async addResultForFlowNode(flowNodeId: string, result: any): Promise<void> {
+  public addResultForFlowNode(flowNodeId: string, result: any): void {
     const processTokenResult: IProcessTokenResult = {
       flowNodeId: flowNodeId,
       result: result,
@@ -54,28 +54,27 @@ export class ProcessTokenFacade implements IProcessTokenFacade {
     this.processTokenResults.push(processTokenResult);
   }
 
-  public async importResults(processTokenResults: Array<IProcessTokenResult>): Promise<void> {
+  public importResults(processTokenResults: Array<IProcessTokenResult>): void {
     Array.prototype.push.apply(this.processTokenResults, processTokenResults);
   }
 
-  public async getProcessTokenFacadeForParallelBranch(): Promise<IProcessTokenFacade> {
+  public getProcessTokenFacadeForParallelBranch(): IProcessTokenFacade {
 
     const processTokenFacade: any = new ProcessTokenFacade(this.processInstanceId, this.processModelId, this.correlationId, this.identity);
-    const allResults: Array<IProcessTokenResult> = await this.getAllResults();
-    await processTokenFacade.importResults(allResults);
+    const allResults: Array<IProcessTokenResult> = this.getAllResults();
+    processTokenFacade.importResults(allResults);
 
     return processTokenFacade;
   }
 
-  public async mergeTokenHistory(processTokenToMerge: IProcessTokenFacade): Promise<void> {
-    const allResultsToMerge: Array<IProcessTokenResult> = await processTokenToMerge.getAllResults();
-
+  public mergeTokenHistory(processTokenToMerge: IProcessTokenFacade): void {
+    const allResultsToMerge: Array<IProcessTokenResult> = processTokenToMerge.getAllResults();
     Array.prototype.push.apply(this.processTokenResults, allResultsToMerge);
   }
 
-  public async getOldTokenFormat(): Promise<any> {
+  public getOldTokenFormat(): any {
 
-    const tokenResults: Array<IProcessTokenResult> = await this.getAllResults();
+    const tokenResults: Array<IProcessTokenResult> = this.getAllResults();
 
     if (tokenResults.length === 0) {
       return {
@@ -102,32 +101,32 @@ export class ProcessTokenFacade implements IProcessTokenFacade {
     return tokenData;
   }
 
-  public async evaluateMapperForSequenceFlow(sequenceFlow: Model.Types.SequenceFlow): Promise<void> {
+  public evaluateMapperForSequenceFlow(sequenceFlow: Model.Types.SequenceFlow): void {
 
-    const tokenData: any = await this.getOldTokenFormat();
+    const tokenData: any = this.getOldTokenFormat();
 
     const mapper: string = this._getMapper(sequenceFlow);
 
     if (mapper !== undefined) {
       const newCurrent: any = (new Function('token', `return ${mapper}`)).call(tokenData, tokenData);
 
-      const allResults: Array<IProcessTokenResult> = await this.getAllResults();
+      const allResults: Array<IProcessTokenResult> = this.getAllResults();
       const currentResult: IProcessTokenResult = allResults[allResults.length - 1];
 
       currentResult.result = newCurrent;
     }
   }
 
-  public async evaluateMapperForFlowNode(flowNode: Model.Base.FlowNode): Promise<void> {
+  public evaluateMapperForFlowNode(flowNode: Model.Base.FlowNode): void {
 
-    const tokenData: any = await this.getOldTokenFormat();
+    const tokenData: any = this.getOldTokenFormat();
 
     const mapper: string = this._getMapper(flowNode);
 
     if (mapper !== undefined) {
       const newCurrent: any = (new Function('token', `return ${mapper}`)).call(tokenData, tokenData);
 
-      const allResults: Array<IProcessTokenResult> = await this.getAllResults();
+      const allResults: Array<IProcessTokenResult> = this.getAllResults();
       const currentResult: IProcessTokenResult = allResults[allResults.length - 1];
 
       currentResult.result = newCurrent;


### PR DESCRIPTION
**Changes:**

1. Make `ProcessTokenFacade` run synchronously. It never made any kind of sense to have it run in Promises, because it doesn't actually perform any kind of async operations.
2. Add new `FlowNodeHandlerInterruptable` base handler, which provides functionality for interrupting a handler. This allows for the BoundaryEvents to be actually interruptible.
3. Derive all activity handlers from the new `FlowNodeHandlerInterruptable` and implement support for interruption.
4. Switch to Bluebird Promises to support Promise cancellation
    - This allows a handler to actually abort its operation, as soon as an interrupt-call is made. I tested this and can confirm that as soon as `BluebirdPromise.cancel` is called, the Bluebird-based promise is truly aborted.
    - Bluebird also provides full stack traces with rejected Promises, which is immensely useful for debugging.
    - Also, since Bluebird runs faster than native promises and is able to free up resources from canceled promises, we received a significant performance boost.
    - **NOTE**: Service Tasks will not be affected by this, since they delegate their work to external components, over which we have no control. If those use native Promises, then there is no way to cancel those.
5. Every BoundaryEvent now calls its decorated handlers `interrupt` function, as soon as the triggering event occurs.
    - BoundaryEvents also provide an `interrupt` function of their own, to ensure that chained BoundaryEvents will pass to call through to the handler.
6. Refactor the TimerBoundaryEvent handler - Timer subscription is now only done in one separate function, just as it is done in the other handlers 
7. Remove some unnecessary Promise wrapping from synchronous functions.

**Issues:** 

Implements: https://github.com/process-engine/process_engine_runtime/issues/176

PR: #218

**Note**:
Since we cannot interrupt a running ProcessInstance yet, the handlers for Subprocesses and CallActivities have not been refactored, because there is little point in doing so.

## How can others test the changes?

Run mutliple scenarios where you have interrupting boundary events and see that their decorated handlers will now truly be canceled, as soon as the interrupt-command is given.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Fixing Security Issues   | `:lock:`             | 🔒     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️      |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️      |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
