### PR TITLE
✨ Add a Timer Validation

### DIFF
--- a/src/model/parser/event_parser.ts
+++ b/src/model/parser/event_parser.ts
@@ -254,8 +254,8 @@ function validateTimer(rawTimerDefinition: any): void {
 function validateTimerValue(timerType: TimerDefinitionType, timerValue: string): void {
   switch (timerType) {
     case TimerDefinitionType.date: {
-      const iso8601DateIsInvalid: boolean = !moment(timerValue, moment.ISO_8601).isValid();
-      if (iso8601DateIsInvalid) {
+      const dateIsInvalid: boolean = !moment(timerValue, moment.ISO_8601).isValid();
+      if (dateIsInvalid) {
         const errorMessage: string = `The given date definition ${timerValue} is not in ISO8601 format`;
         throw new UnprocessableEntityError(errorMessage);
       }
@@ -278,9 +278,9 @@ function validateTimerValue(timerType: TimerDefinitionType, timerValue: string):
        */
        /*tslint:disable-next-line:max-line-length*/
       const durationRegex: RegExp = /^P(?!$)(\d+(?:\.\d+)?Y)?(\d+(?:\.\d+)?M)?(\d+(?:\.\d+)?W)?(\d+(?:\.\d+)?D)?(T(?=\d)(\d+(?:\.\d+)?H)?(\d+(?:\.\d+)?M)?(\d+(?:\.\d+)?S)?)?$/gm;
-      const iso8601DurationIsInvalid: boolean = !durationRegex.test(timerValue);
+      const durationIsInvalid: boolean = !durationRegex.test(timerValue);
 
-      if (iso8601DurationIsInvalid) {
+      if (durationIsInvalid) {
         const errorMessage: string = `The given duration definition ${timerValue} is not in ISO8601 format`;
         throw new UnprocessableEntityError(errorMessage);
       }

--- a/src/model/parser/event_parser.ts
+++ b/src/model/parser/event_parser.ts
@@ -289,12 +289,7 @@ function validateTimerValue(timerType: TimerDefinitionType, timerValue: string):
     }
 
     case TimerDefinitionType.cycle: {
-      /**
-       * This issue currently blocks the validation for Cyclic timers:
-       * https://github.com/process-engine/process_engine_runtime/issues/196
-       */
       throw new UnprocessableEntityError('Cyclic timer definitions are currently unsupported!');
-      break;
     }
 
     default: {
@@ -303,12 +298,6 @@ function validateTimerValue(timerType: TimerDefinitionType, timerValue: string):
   }
 }
 
-/**
- * TODO: Both of the following functions are copied from the
- * timer_facade.
- * It would be nicer, if we could use an actual timer_facade instance here,
- * which we can obtain from the ioc container.
- */
 function parseTimerDefinitionType(eventDefinition: any): TimerDefinitionType {
 
   const timerIsDuration: boolean = eventDefinition[TimerBpmnType.Duration] !== undefined;

--- a/src/model/parser/event_parser.ts
+++ b/src/model/parser/event_parser.ts
@@ -176,8 +176,8 @@ function assignEventDefinition(event: any, eventRaw: any, eventRawTagName: BpmnT
       event[targetPropertyName] = getDefinitionForEvent(eventDefinitonValue.signalRef);
       break;
     case 'timerEventDefinition':
-      event[targetPropertyName] = eventDefinitonValue;
       validateTimer(eventDefinitonValue);
+      event[targetPropertyName] = eventDefinitonValue;
       break;
     default:
       event[targetPropertyName] = {};

--- a/src/model/parser/event_parser.ts
+++ b/src/model/parser/event_parser.ts
@@ -177,7 +177,6 @@ function assignEventDefinition(event: any, eventRaw: any, eventRawTagName: BpmnT
       break;
     case 'timerEventDefinition':
       event[targetPropertyName] = eventDefinitonValue;
-      debugger;
       validateTimer(eventDefinitonValue);
       break;
     default:

--- a/src/runtime/persistence/process_model_service.ts
+++ b/src/runtime/persistence/process_model_service.ts
@@ -114,9 +114,12 @@ export class ProcessModelService implements IProcessModelService {
       parsedProcessDefinition = await this._bpmnModelParser.parseXmlToObjectModel(xml);
     } catch (error) {
       logger.error(`The XML for process "${name}" could not be parsed: ${error.message}`);
-      const genericMessage: string = `The XML for process "${name}" could not be parsed.`;
-      const cause: string = error.message ? `\nCause: ${error.message}` : '';
-      throw new UnprocessableEntityError(`${genericMessage}${cause}`);
+      const errorMessage: string = `The XML for process "${name}" could not be parsed.`;
+      const parsingError: UnprocessableEntityError = new UnprocessableEntityError(errorMessage);
+
+      parsingError.additionalInformation = error;
+
+      throw parsingError;
     }
 
     const processDefinitionHasMoreThanOneProcessModel: boolean = parsedProcessDefinition.processes.length > 1;

--- a/src/runtime/persistence/process_model_service.ts
+++ b/src/runtime/persistence/process_model_service.ts
@@ -114,7 +114,9 @@ export class ProcessModelService implements IProcessModelService {
       parsedProcessDefinition = await this._bpmnModelParser.parseXmlToObjectModel(xml);
     } catch (error) {
       logger.error(`The XML for process "${name}" could not be parsed: ${error.message}`);
-      throw new UnprocessableEntityError(`The XML for process "${name}" could not be parsed.`);
+      const genericMessage: string = `The XML for process "${name}" could not be parsed.`;
+      const cause: string = error.message ? `\nCause: ${error.message}` : '';
+      throw new UnprocessableEntityError(`${genericMessage}${cause}`);
     }
 
     const processDefinitionHasMoreThanOneProcessModel: boolean = parsedProcessDefinition.processes.length > 1;


### PR DESCRIPTION
**Changes:**

1. Adds a timer validation which validates, if the user passed the `TimerDefinition` in the right format/syntax
2. Throw a 400 Error if the user tries to upload a ProcessDefinitions, which contains a cyclic timer definition, since we currently don't support these.

**Issues:**

Related: https://github.com/process-engine/process_engine_runtime/issues/195

PR: #226

## How can others test the changes?

> Describe how others can test your changes (you can remove this section for typo fixes etc.)

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).