### PR TITLE
🐛 Fix claim checks on empty lane sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "8.7.2",
+  "version": "8.7.3",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/persistence/process_model_service.ts
+++ b/src/runtime/persistence/process_model_service.ts
@@ -191,7 +191,8 @@ export class ProcessModelService implements IProcessModelService {
 
     const processModelCopy: Model.Types.Process = clone(processModel);
 
-    if (!processModel.laneSet) {
+    const processModelHasNoLanes: boolean = !(processModel.laneSet && processModel.laneSet.lanes && processModel.laneSet.lanes.length > 0);
+    if (processModelHasNoLanes) {
       return processModelCopy;
     }
 


### PR DESCRIPTION
**Changes:**

Fixes an issue where requesting a ProcessModel that contains either an empty laneSet or no laneSets at all resulted in a 403 error.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/215

PR: #233

## How can others test the changes?

Try deploying and then retrieving a ProcessModel that has either an empty lane set or no lane set at all.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).