### PR TITLE
✨ Add validations for ProcessModel persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "8.7.3",
+  "version": "8.7.4",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/persistence/process_model_service.ts
+++ b/src/runtime/persistence/process_model_service.ts
@@ -105,10 +105,25 @@ export class ProcessModelService implements IProcessModelService {
    * @param xml  The xml code of the ProcessDefinition to validate.
    */
   private async _validateDefinition(name: string, xml: string): Promise<void> {
+
+    let parsedProcessDefinition: Definitions;
+
     try {
-      await this._bpmnModelParser.parseXmlToObjectModel(xml);
+      parsedProcessDefinition = await this._bpmnModelParser.parseXmlToObjectModel(xml);
     } catch (error) {
       throw new UnprocessableEntityError(`The XML for process "${name}" could not be parsed.`);
+    }
+
+    const processDefinitionHasMoreThanOneProcessModel: boolean = parsedProcessDefinition.processes.length > 1;
+    if (processDefinitionHasMoreThanOneProcessModel) {
+      throw new UnprocessableEntityError(`The XML for process "${name}" contains more than one ProcessModel. This is currently not supported.`);
+    }
+
+    const processsModel: Model.Types.Process = parsedProcessDefinition.processes[0];
+
+    const processModelIdIsNotEqualToDefinitionName: boolean = processsModel.id !== name;
+    if (processModelIdIsNotEqualToDefinitionName) {
+      throw new UnprocessableEntityError(`The ProcessModel contained within the diagram "${name}" must also use the name "${name}"!`);
     }
   }
 


### PR DESCRIPTION
**Changes:**

1. Add more validations for ProcessModel deployment
    - ProcessDefinitions must only contain one ProcessModel (Multiple ProcessModels are not supported right now)
    - A ProcessModels ID must match the provided name under which the definition is to be stored (See linked issue).
2. Add some error logging to the `ProcessModelService`
3. Remove unnecessary Bluebird import from `ProcessModelService` (Bluebird Promises are now used by default).

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/219

PR: #234

## How can others test the changes?

Try importing ProcessModels that violate the restrictions described above.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).