### PR TITLE
🐛 Fix ExternalTask payload evaluation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "8.8.0",
+  "version": "8.8.1",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/engine/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -1,5 +1,6 @@
 import {Logger} from 'loggerhythm';
 
+import {InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
@@ -147,27 +148,30 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
 
     const handlerPromise: Promise<NextFlowNodeInfo> = new Promise<NextFlowNodeInfo>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      this.logger.verbose('Executing external ServiceTask');
-      await this.persistOnSuspend(token);
-      const externalTaskExecutorPromise: Promise<any> = this._executeExternalServiceTask(token, processTokenFacade, identity);
+      try {
+        this.logger.verbose('Executing external ServiceTask');
+        await this.persistOnSuspend(token);
+        const externalTaskExecutorPromise: Promise<any> = this._executeExternalServiceTask(token, processTokenFacade, identity);
 
-      this.onInterruptedCallback = (): void => {
-        externalTaskExecutorPromise.cancel();
-        handlerPromise.cancel();
+        this.onInterruptedCallback = (): void => {
+          externalTaskExecutorPromise.cancel();
+          handlerPromise.cancel();
 
-        return;
-      };
+          return;
+        };
+        const result: any = await externalTaskExecutorPromise;
 
-      const result: any = await externalTaskExecutorPromise;
+        processTokenFacade.addResultForFlowNode(this.serviceTask.id, result);
+        token.payload = result;
 
-      processTokenFacade.addResultForFlowNode(this.serviceTask.id, result);
-      token.payload = result;
+        await this.persistOnExit(token);
 
-      await this.persistOnExit(token);
+        const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
 
-      const nextFlowNodeInfo: NextFlowNodeInfo = this.getNextFlowNodeInfo(token, processTokenFacade, processModelFacade);
-
-      return resolve(nextFlowNodeInfo);
+        return resolve(nextFlowNodeInfo);
+      } catch (error) {
+        return reject(error);
+      }
     });
 
     return handlerPromise;
@@ -194,12 +198,12 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
     return new Promise<any>(async(resolve: Function, reject: Function): Promise<any> => {
 
       try {
-
         const externalTaskFinishedCallback: Function = async(error: Error, result: any): Promise<void> => {
 
           if (error) {
             this.logger.error(`The external worker failed to process the ExternalTask!`, error);
-            throw error;
+
+            return reject(error);
           }
 
           this.logger.verbose('The external worker successfully finished processing the ExternalTask.');
@@ -207,7 +211,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
 
           await this.persistOnResume(token);
 
-          resolve(result);
+          return resolve(result);
         };
 
         this._waitForExternalTaskResult(externalTaskFinishedCallback);
@@ -219,12 +223,12 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
         this._publishExternalTaskCreatedNotification();
 
         this.logger.verbose('Waiting for external ServiceTask to be finished by an external worker.');
-
       } catch (error) {
         this.logger.error('Failed to execute external ServiceTask!');
         this.logger.error(error);
         await this.persistOnError(token, error);
-        throw error;
+
+        return reject(error);
       }
     });
   }
@@ -280,14 +284,21 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
    */
   private _getServiceTaskPayload(token: Runtime.Types.ProcessToken, tokenHistory: any, identity: IIdentity): any {
 
-    const serviceTaskHasAttachedPayload: boolean = this.serviceTask.payload !== undefined;
+    try {
+      const serviceTaskHasAttachedPayload: boolean = this.serviceTask.payload !== undefined;
 
-    if (serviceTaskHasAttachedPayload) {
-      const evaluatePayloadFunction: Function = new Function('token', 'identity', `return ${this.serviceTask.payload}`);
+      if (serviceTaskHasAttachedPayload) {
+        const evaluatePayloadFunction: Function = new Function('token', 'identity', `return ${this.serviceTask.payload}`);
 
-      return evaluatePayloadFunction.call(tokenHistory, tokenHistory, identity);
-    } else {
-      return token.payload;
+        return evaluatePayloadFunction.call(tokenHistory, tokenHistory, identity);
+      } else {
+        return token.payload;
+      }
+    } catch (error) {
+      const errorMessage: string = `ExternalTask payload configuration '${this.serviceTask.payload}' is invalid!`;
+      this.logger.error(errorMessage);
+
+      throw new InternalServerError(errorMessage);
     }
   }
 


### PR DESCRIPTION
**Changes:**

Fix the error handling for misconfigured ExternalTak payloads, by making use of explicit Promise-rejection.

We need to do this explicitly, because otherwise the rejection would get swallowed up.
This would make the ProcessEngine appear to have frozen.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/216

PR: #235

## How can others test the changes?

- Try executing an ExternalTask that attempts to use a non-existent ProcessToken property as a payload.
- The resulting error should now be handled and returned correctly.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).