### PR TITLE
✨Do not Throw an Error when a Process Contains a Cyclic TimerStartEvent and a Normal StartEvent

### DIFF
--- a/src/model/parser/event_parser.ts
+++ b/src/model/parser/event_parser.ts
@@ -159,8 +159,6 @@ function parseEventsByType<TEvent extends Model.Events.Event>(
     return false;
   })();
 
-  debugger;
-
   for (const eventRaw of eventsRaw) {
     const event: TEvent = createObjectWithCommonProperties<TEvent>(eventRaw, type);
     event.name = eventRaw.name;

--- a/src/model/parser/event_parser.ts
+++ b/src/model/parser/event_parser.ts
@@ -326,6 +326,10 @@ function validateTimerValue(timerType: TimerDefinitionType, timerValue: string, 
 
     case TimerDefinitionType.cycle: {
 
+      /**
+       * We don't want to reject ProcessModels whose contain a Cyclic TimerStartEvent
+       * alongside a normal StartEvent for compatibility reasons.
+       */
       if (ignoreCyclic) {
         const logger: Logger = Logger.createLogger('processengine:runtime:model:parser:event_parser');
         logger.warn('Cyclic Timer Events are currently not supported.');

--- a/src/model/parser/event_parser.ts
+++ b/src/model/parser/event_parser.ts
@@ -83,7 +83,7 @@ function parseEndEvent(endEventRaw: any): Model.Events.EndEvent {
   endEvent.incoming = getModelPropertyAsArray(endEventRaw, BpmnTags.FlowElementProperty.SequenceFlowIncoming);
   endEvent.outgoing = getModelPropertyAsArray(endEventRaw, BpmnTags.FlowElementProperty.SequenceFlowOutgoing);
 
-  assignEventDefinitions(endEvent, endEventRaw, false);
+  assignEventDefinitions(endEvent, endEventRaw);
 
   return endEvent;
 }
@@ -108,7 +108,7 @@ function parseBoundaryEvents(processData: any): Array<Model.Events.BoundaryEvent
     event.attachedToRef = boundaryEventRaw.attachedToRef;
     event.cancelActivity = boundaryEventRaw.cancelActivity || true;
 
-    assignEventDefinitions(event, boundaryEventRaw, false);
+    assignEventDefinitions(event, boundaryEventRaw);
 
     events.push(event);
   }
@@ -173,12 +173,12 @@ function parseEventsByType<TEvent extends Model.Events.Event>(
   return events;
 }
 
-function assignEventDefinitions(event: any, eventRaw: any, ignoreCyclicTimer: boolean): void {
-  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.ErrorEventDefinition, 'errorEventDefinition', ignoreCyclicTimer);
-  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.LinkEventDefinition, 'linkEventDefinition', ignoreCyclicTimer);
-  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.MessageEventDefinition, 'messageEventDefinition', ignoreCyclicTimer);
-  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.SignalEventDefinition, 'signalEventDefinition', ignoreCyclicTimer);
-  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.TerminateEventDefinition, 'terminateEventDefinition', ignoreCyclicTimer);
+function assignEventDefinitions(event: any, eventRaw: any, ignoreCyclicTimer?: boolean): void {
+  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.ErrorEventDefinition, 'errorEventDefinition');
+  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.LinkEventDefinition, 'linkEventDefinition');
+  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.MessageEventDefinition, 'messageEventDefinition');
+  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.SignalEventDefinition, 'signalEventDefinition');
+  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.TerminateEventDefinition, 'terminateEventDefinition');
   assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.TimerEventDefinition, 'timerEventDefinition', ignoreCyclicTimer);
 }
 
@@ -186,7 +186,7 @@ function assignEventDefinition(
   event: any, eventRaw: any,
   eventRawTagName: BpmnTags.FlowElementProperty,
   targetPropertyName: string,
-  ignoreCyclicTimer: boolean,
+  ignoreCyclicTimer?: boolean,
 ): void {
 
   const eventDefinitonValue: any = eventRaw[eventRawTagName];

--- a/test/bpmns/process_engine_io_release.bpmn
+++ b/test/bpmns/process_engine_io_release.bpmn
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definition_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="BPMN Studio" exporterVersion="1">
+  <bpmn:collaboration id="Collaboration_1cidyxu" name="">
+    <bpmn:participant id="Participant_0px403d" name="process_engine_io_release" processRef="process_engine_io_release" />
+  </bpmn:collaboration>
+  <bpmn:process id="process_engine_io_release" name="process_engine_io_release" isExecutable="true">
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_1xzf0d3" name="Release Manager">
+        <bpmn:flowNodeRef>release_durchfuehren</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ExclusiveGateway_0e7oytx</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_0y6uwzm</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ExclusiveGateway_1rtxky2</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ExclusiveGateway_1avo21q</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_0eie6q6</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_1tfjjzx</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_0a4b1bm</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_0bbikg1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ExclusiveGateway_1gvf165</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ausserordentlicher_start</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>jeden_donnerstag_start</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:sequenceFlow id="SequenceFlow_0c373kd" sourceRef="jeden_donnerstag_start" targetRef="release_durchfuehren" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oy0eez" sourceRef="release_durchfuehren" targetRef="ExclusiveGateway_0e7oytx" />
+    <bpmn:userTask id="release_durchfuehren" name="Release durchführen?" camunda:formKey="Form Key">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="release_durchfuehren" label="Soll ein process-engine.io Release erstellt werden? " type="boolean" defaultValue="" />
+        </camunda:formData>
+        <camunda:properties>
+          <camunda:property name="preferredControl" value="confirm" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0c373kd</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oy0eez</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0qg5z1e" name="Ja" sourceRef="ExclusiveGateway_0e7oytx" targetRef="ExclusiveGateway_1gvf165">
+      <bpmn:extensionElements>
+        <camunda:formData />
+      </bpmn:extensionElements>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">token.current.form_fields.release_durchfuehren === 'true'</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_0e7oytx" name="">
+      <bpmn:extensionElements>
+        <camunda:formData />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1oy0eez</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0qg5z1e</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1ukf8v1</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1ukf8v1" name="Nein" sourceRef="ExclusiveGateway_0e7oytx" targetRef="EndEvent_0y6uwzm">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">token.current.form_fields.release_durchfuehren === 'false'</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="EndEvent_0y6uwzm" name="Kein Release">
+      <bpmn:incoming>SequenceFlow_1ukf8v1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:parallelGateway id="ExclusiveGateway_1rtxky2" name="">
+      <bpmn:extensionElements>
+        <camunda:formData />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0uaexrv</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_10xcr5a</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_10lignn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0822sfy</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="ExclusiveGateway_1avo21q" name="">
+      <bpmn:extensionElements>
+        <camunda:formData />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_07juolu</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1nt9fw9</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1vprubq</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_17awqho</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="EndEvent_0eie6q6" name="Release erstellt">
+      <bpmn:incoming>SequenceFlow_0822sfy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Task_1tfjjzx" name="BPMN-Studio releasen" calledElement="bpmn_studio_release">
+      <bpmn:incoming>SequenceFlow_1nt9fw9</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0uaexrv</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="Task_0a4b1bm" name="ProcessEngine.ts releasen" calledElement="process_engine_ts_release">
+      <bpmn:incoming>SequenceFlow_1vprubq</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_10xcr5a</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="Task_0bbikg1" name="ProcessEngine.NET releasen" calledElement="process_engine_net_release">
+      <bpmn:incoming>SequenceFlow_17awqho</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_10lignn</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="SequenceFlow_0uaexrv" sourceRef="Task_1tfjjzx" targetRef="ExclusiveGateway_1rtxky2" />
+    <bpmn:sequenceFlow id="SequenceFlow_10xcr5a" sourceRef="Task_0a4b1bm" targetRef="ExclusiveGateway_1rtxky2" />
+    <bpmn:sequenceFlow id="SequenceFlow_10lignn" sourceRef="Task_0bbikg1" targetRef="ExclusiveGateway_1rtxky2" />
+    <bpmn:sequenceFlow id="SequenceFlow_0822sfy" sourceRef="ExclusiveGateway_1rtxky2" targetRef="EndEvent_0eie6q6" />
+    <bpmn:sequenceFlow id="SequenceFlow_1nt9fw9" sourceRef="ExclusiveGateway_1avo21q" targetRef="Task_1tfjjzx" />
+    <bpmn:sequenceFlow id="SequenceFlow_1vprubq" sourceRef="ExclusiveGateway_1avo21q" targetRef="Task_0a4b1bm" />
+    <bpmn:sequenceFlow id="SequenceFlow_17awqho" sourceRef="ExclusiveGateway_1avo21q" targetRef="Task_0bbikg1" />
+    <bpmn:sequenceFlow id="SequenceFlow_07juolu" sourceRef="ExclusiveGateway_1gvf165" targetRef="ExclusiveGateway_1avo21q" />
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1gvf165" name="">
+      <bpmn:incoming>SequenceFlow_0qg5z1e</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0z1m3md</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_07juolu</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_0z1m3md" sourceRef="ausserordentlicher_start" targetRef="ExclusiveGateway_1gvf165" />
+    <bpmn:startEvent id="ausserordentlicher_start" name="Außerordentliches Release">
+      <bpmn:outgoing>SequenceFlow_0z1m3md</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="jeden_donnerstag_start" name="Jeden Donnerstag">
+      <bpmn:outgoing>SequenceFlow_0c373kd</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 9 * * 4</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cidyxu">
+      <bpmndi:BPMNShape id="Participant_0px403d_di" bpmnElement="Participant_0px403d">
+        <dc:Bounds x="5" y="4" width="1221" height="513" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1xzf0d3_di" bpmnElement="Lane_1xzf0d3">
+        <dc:Bounds x="35" y="4" width="1191" height="513" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0eie6q6_di" bpmnElement="EndEvent_0eie6q6">
+        <dc:Bounds x="1118" y="179" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1099" y="215" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0c373kd_di" bpmnElement="SequenceFlow_0c373kd">
+        <di:waypoint x="110" y="197" />
+        <di:waypoint x="150" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0b5yf50_di" bpmnElement="release_durchfuehren">
+        <dc:Bounds x="150" y="157" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oy0eez_di" bpmnElement="SequenceFlow_1oy0eez">
+        <di:waypoint x="250" y="197" />
+        <di:waypoint x="314" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ParallelGateway_0oetzm5_di" bpmnElement="ExclusiveGateway_1avo21q">
+        <dc:Bounds x="583" y="172" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1nt9fw9_di" bpmnElement="SequenceFlow_1nt9fw9">
+        <di:waypoint x="608" y="172" />
+        <di:waypoint x="608" y="87" />
+        <di:waypoint x="744" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1vprubq_di" bpmnElement="SequenceFlow_1vprubq">
+        <di:waypoint x="633" y="197" />
+        <di:waypoint x="744" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_17awqho_di" bpmnElement="SequenceFlow_17awqho">
+        <di:waypoint x="608" y="222" />
+        <di:waypoint x="608" y="307" />
+        <di:waypoint x="744" y="307" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0uaexrv_di" bpmnElement="SequenceFlow_0uaexrv">
+        <di:waypoint x="844" y="87" />
+        <di:waypoint x="981" y="87" />
+        <di:waypoint x="981" y="172" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ParallelGateway_1gc9nj8_di" bpmnElement="ExclusiveGateway_1rtxky2">
+        <dc:Bounds x="956" y="172" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_10xcr5a_di" bpmnElement="SequenceFlow_10xcr5a">
+        <di:waypoint x="844" y="197" />
+        <di:waypoint x="956" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10lignn_di" bpmnElement="SequenceFlow_10lignn">
+        <di:waypoint x="844" y="307" />
+        <di:waypoint x="981" y="307" />
+        <di:waypoint x="981" y="222" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0822sfy_di" bpmnElement="SequenceFlow_0822sfy">
+        <di:waypoint x="1006" y="197" />
+        <di:waypoint x="1118" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="CallActivity_1pmfcmh_di" bpmnElement="Task_1tfjjzx">
+        <dc:Bounds x="744" y="47" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_04njkzx_di" bpmnElement="Task_0a4b1bm">
+        <dc:Bounds x="744" y="157" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_11muuci_di" bpmnElement="Task_0bbikg1">
+        <dc:Bounds x="744" y="267" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_0e7oytx_di" bpmnElement="ExclusiveGateway_0e7oytx" isMarkerVisible="true">
+        <dc:Bounds x="314" y="172" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0qg5z1e_di" bpmnElement="SequenceFlow_0qg5z1e">
+        <di:waypoint x="364" y="197" />
+        <di:waypoint x="463" y="197" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="408" y="179" width="12" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0y6uwzm_di" bpmnElement="EndEvent_0y6uwzm">
+        <dc:Bounds x="321" y="303" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="306" y="346" width="66" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ukf8v1_di" bpmnElement="SequenceFlow_1ukf8v1">
+        <di:waypoint x="339" y="222" />
+        <di:waypoint x="339" y="303" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="343" y="260" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_193grq1_di" bpmnElement="ausserordentlicher_start">
+        <dc:Bounds x="74" y="59" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="50" y="102" width="84" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1gvf165_di" bpmnElement="ExclusiveGateway_1gvf165" isMarkerVisible="true">
+        <dc:Bounds x="463" y="172" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_07juolu_di" bpmnElement="SequenceFlow_07juolu">
+        <di:waypoint x="513" y="197" />
+        <di:waypoint x="583" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0z1m3md_di" bpmnElement="SequenceFlow_0z1m3md">
+        <di:waypoint x="110" y="77" />
+        <di:waypoint x="488" y="77" />
+        <di:waypoint x="488" y="172" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_1aye226_di" bpmnElement="jeden_donnerstag_start">
+        <dc:Bounds x="74" y="179" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="48" y="215" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/runtime/engine/process_model_facade.spec.ts
+++ b/test/runtime/engine/process_model_facade.spec.ts
@@ -41,7 +41,7 @@ describe('Process Model Facade', () => {
 
       should(invocation.module).be.eql('HttpService');
       should(invocation.method).be.eql('post');
-      should(invocation.params).be.eql('[\'http://localhost:5000/api/vorgaenge/anlegen\', token.history.VorgangErfassen]');
+      should(invocation.params).be.eql('[\'http:localhost:5000/api/vorgaenge/anlegen\', token.history.VorgangErfassen]');
     });
   });
 
@@ -52,34 +52,34 @@ describe('Process Model Facade', () => {
       const fixture: ProcessModelFacadeTestFixture = new ProcessModelFacadeTestFixture();
       await fixture.initialize('./test/bpmns/process_engine_io_release.bpmn');
 
-      // await fixture.assertFlowNodes([
-      //   'StartEvent_1',
-      //   'VorgangErfassen',
-      //   'Task_01xg9lr',
-      //   'Task_00dom74',
-      //   'notizSchreiben',
-      //   'Task_1tk0lhq',
-      //   'Task_1yzqmfq',
-      //   'EndEvent_05uuvaq',
-      // ]);
+      await fixture.assertFlowNodes([
+         'StartEvent_1',
+         'VorgangErfassen',
+         'Task_01xg9lr',
+         'Task_00dom74',
+         'notizSchreiben',
+         'Task_1tk0lhq',
+         'Task_1yzqmfq',
+         'EndEvent_05uuvaq',
+       ]);
 
-      // await fixture.assertFlowNodes([
-      //   'StartEvent_1',
-      //   'VorgangErfassen',
-      //   'Task_01xg9lr',
-      //   'Task_00dom74',
-      //   'notizSchreiben',
-      //   'Task_1tk0lhq',
-      //   'Task_1yzqmfq',
-      //   'EndEvent_05uuvaq',
-      // ]);
+      await fixture.assertFlowNodes([
+         'StartEvent_1',
+         'VorgangErfassen',
+         'Task_01xg9lr',
+         'Task_00dom74',
+         'notizSchreiben',
+         'Task_1tk0lhq',
+         'Task_1yzqmfq',
+         'EndEvent_05uuvaq',
+       ]);
 
-      // const vorgangAnlegen: Model.Activities.ServiceTask = fixture.getFlowNodeById<Model.Activities.ServiceTask>('Task_01xg9lr');
-      // const invocation: Model.Activities.MethodInvocation = vorgangAnlegen.invocation as Model.Activities.MethodInvocation;
+      const vorgangAnlegen: Model.Activities.ServiceTask = fixture.getFlowNodeById<Model.Activities.ServiceTask>('Task_01xg9lr');
+      const invocation: Model.Activities.MethodInvocation = vorgangAnlegen.invocation as Model.Activities.MethodInvocation;
 
-      // should(invocation.module).be.eql('HttpService');
-      // should(invocation.method).be.eql('post');
-      // should(invocation.params).be.eql('[\'http://localhost:5000/api/vorgaenge/anlegen\', token.history.VorgangErfassen]');
+      should(invocation.module).be.eql('HttpService');
+      should(invocation.method).be.eql('post');
+      should(invocation.params).be.eql('[\'http:localhost:5000/api/vorgaenge/anlegen\', token.history.VorgangErfassen]');
     });
   });
 });

--- a/test/runtime/engine/process_model_facade.spec.ts
+++ b/test/runtime/engine/process_model_facade.spec.ts
@@ -44,4 +44,42 @@ describe('Process Model Facade', () => {
       should(invocation.params).be.eql('[\'http://localhost:5000/api/vorgaenge/anlegen\', token.history.VorgangErfassen]');
     });
   });
+
+  describe('Parse process_engine_io_release.bpmn Diagram', () => {
+
+    it('Should parse expected process', async() => {
+
+      const fixture: ProcessModelFacadeTestFixture = new ProcessModelFacadeTestFixture();
+      await fixture.initialize('./test/bpmns/process_engine_io_release.bpmn');
+
+      // await fixture.assertFlowNodes([
+      //   'StartEvent_1',
+      //   'VorgangErfassen',
+      //   'Task_01xg9lr',
+      //   'Task_00dom74',
+      //   'notizSchreiben',
+      //   'Task_1tk0lhq',
+      //   'Task_1yzqmfq',
+      //   'EndEvent_05uuvaq',
+      // ]);
+
+      // await fixture.assertFlowNodes([
+      //   'StartEvent_1',
+      //   'VorgangErfassen',
+      //   'Task_01xg9lr',
+      //   'Task_00dom74',
+      //   'notizSchreiben',
+      //   'Task_1tk0lhq',
+      //   'Task_1yzqmfq',
+      //   'EndEvent_05uuvaq',
+      // ]);
+
+      // const vorgangAnlegen: Model.Activities.ServiceTask = fixture.getFlowNodeById<Model.Activities.ServiceTask>('Task_01xg9lr');
+      // const invocation: Model.Activities.MethodInvocation = vorgangAnlegen.invocation as Model.Activities.MethodInvocation;
+
+      // should(invocation.module).be.eql('HttpService');
+      // should(invocation.method).be.eql('post');
+      // should(invocation.params).be.eql('[\'http://localhost:5000/api/vorgaenge/anlegen\', token.history.VorgangErfassen]');
+    });
+  });
 });

--- a/test/runtime/engine/process_model_facade.spec.ts
+++ b/test/runtime/engine/process_model_facade.spec.ts
@@ -25,23 +25,12 @@ describe('Process Model Facade', () => {
         'EndEvent_05uuvaq',
       ]);
 
-      await fixture.assertFlowNodes([
-        'StartEvent_1',
-        'VorgangErfassen',
-        'Task_01xg9lr',
-        'Task_00dom74',
-        'notizSchreiben',
-        'Task_1tk0lhq',
-        'Task_1yzqmfq',
-        'EndEvent_05uuvaq',
-      ]);
-
       const vorgangAnlegen: Model.Activities.ServiceTask = fixture.getFlowNodeById<Model.Activities.ServiceTask>('Task_01xg9lr');
       const invocation: Model.Activities.MethodInvocation = vorgangAnlegen.invocation as Model.Activities.MethodInvocation;
 
       should(invocation.module).be.eql('HttpService');
       should(invocation.method).be.eql('post');
-      should(invocation.params).be.eql('[\'http:localhost:5000/api/vorgaenge/anlegen\', token.history.VorgangErfassen]');
+      should(invocation.params).be.eql('[\'http://localhost:5000/api/vorgaenge/anlegen\', token.history.VorgangErfassen]');
     });
   });
 
@@ -53,33 +42,13 @@ describe('Process Model Facade', () => {
       await fixture.initialize('./test/bpmns/process_engine_io_release.bpmn');
 
       await fixture.assertFlowNodes([
-         'StartEvent_1',
-         'VorgangErfassen',
-         'Task_01xg9lr',
-         'Task_00dom74',
-         'notizSchreiben',
-         'Task_1tk0lhq',
-         'Task_1yzqmfq',
-         'EndEvent_05uuvaq',
-       ]);
-
-      await fixture.assertFlowNodes([
-         'StartEvent_1',
-         'VorgangErfassen',
-         'Task_01xg9lr',
-         'Task_00dom74',
-         'notizSchreiben',
-         'Task_1tk0lhq',
-         'Task_1yzqmfq',
-         'EndEvent_05uuvaq',
-       ]);
-
-      const vorgangAnlegen: Model.Activities.ServiceTask = fixture.getFlowNodeById<Model.Activities.ServiceTask>('Task_01xg9lr');
-      const invocation: Model.Activities.MethodInvocation = vorgangAnlegen.invocation as Model.Activities.MethodInvocation;
-
-      should(invocation.module).be.eql('HttpService');
-      should(invocation.method).be.eql('post');
-      should(invocation.params).be.eql('[\'http:localhost:5000/api/vorgaenge/anlegen\', token.history.VorgangErfassen]');
+        'ausserordentlicher_start',
+        'ExclusiveGateway_1gvf165',
+        'ExclusiveGateway_1avo21q',
+        'Task_1tfjjzx',
+        'ExclusiveGateway_1rtxky2',
+        'EndEvent_0eie6q6',
+      ]);
     });
   });
 });


### PR DESCRIPTION
**Changes:**

1. Allow Cyclic `TimerStartEvents` on a ProcessModel, if it contains at least one `StartEvent` without such a timer.

**Issues:**

Closes #240 
Related: https://github.com/process-engine/process_engine_runtime/issues/237

PR: #241 

## How can others test the changes?

Try deploying a ProcessModel with a cyclic TimerStartEvent and at least one other type of StartEvent.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).