### PR TITLE
🐛 Expose get by hash on process model service

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@process-engine/consumer_api_contracts": "~4.1.0",
     "@process-engine/logging_api_contracts": "~0.3.0",
     "@process-engine/metrics_api_contracts": "~0.3.0",
-    "@process-engine/process_engine_contracts": "feature~expose_get_by_hash_on_process_model_service",
+    "@process-engine/process_engine_contracts": "~37.0.1",
     "@types/clone": "~0.1.30",
     "@types/socket.io": "~2.1.2",
     "addict-ioc": "~2.5.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@process-engine/consumer_api_contracts": "~4.1.0",
     "@process-engine/logging_api_contracts": "~0.3.0",
     "@process-engine/metrics_api_contracts": "~0.3.0",
-    "@process-engine/process_engine_contracts": "~37.0.0",
+    "@process-engine/process_engine_contracts": "feature~expose_get_by_hash_on_process_model_service",
     "@types/clone": "~0.1.30",
     "@types/socket.io": "~2.1.2",
     "addict-ioc": "~2.5.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",


### PR DESCRIPTION
**Requires:**
https://github.com/process-engine/process_engine_contracts/pull/103

**Changes:**

Add missing `getByHash` method to `ProcessModelService`.

PR: #242

## How can others test the changes?

Use the service to query ProcessModels by their hash.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).