### PR TITLE
🐛 Fix timer expression parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "10.1.5",
+  "version": "10.2.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@process-engine/consumer_api_contracts": "~4.1.0",
     "@process-engine/logging_api_contracts": "~1.0.0",
     "@process-engine/metrics_api_contracts": "~1.0.0",
-    "@process-engine/process_engine_contracts": "feature~fix_timer_token_evaluation",
+    "@process-engine/process_engine_contracts": "~39.1.0",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",
     "addict-ioc": "~2.5.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@process-engine/consumer_api_contracts": "~4.1.0",
     "@process-engine/logging_api_contracts": "~1.0.0",
     "@process-engine/metrics_api_contracts": "~1.0.0",
-    "@process-engine/process_engine_contracts": "~39.0.0",
+    "@process-engine/process_engine_contracts": "feature~fix_timer_token_evaluation",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",
     "addict-ioc": "~2.5.1",

--- a/src/model/parser/event_parser.ts
+++ b/src/model/parser/event_parser.ts
@@ -1,25 +1,11 @@
-import {
-  BpmnTags,
-  Model,
-  TimerDefinitionType,
-} from '@process-engine/process_engine_contracts';
+import {BpmnTags, Model} from '@process-engine/process_engine_contracts';
 
 import {
   createObjectWithCommonProperties,
   getModelPropertyAsArray,
 } from '../type_factory';
 
-import {NotFoundError, UnprocessableEntityError} from '@essential-projects/errors_ts';
-
-import * as moment from 'moment';
-
-import {Logger} from 'loggerhythm';
-
-enum TimerBpmnType {
-  Duration = 'bpmn:timeDuration',
-  Cycle = 'bpmn:timeCycle',
-  Date = 'bpmn:timeDate',
-}
+import {NotFoundError} from '@essential-projects/errors_ts';
 
 let errors: Array<Model.Types.Error> = [];
 let eventDefinitions: Array<Model.EventDefinitions.EventDefinition> = [];
@@ -136,35 +122,13 @@ function parseEventsByType<TEvent extends Model.Events.Event>(
     return [];
   }
 
-  const checkIfCyclicTimersAreSafe: Function = (): boolean => {
-    const cyclicTimerCheckRequired: boolean =
-      eventsRaw.length > 1 &&
-      eventType === BpmnTags.EventElement.StartEvent;
-
-    if (cyclicTimerCheckRequired) {
-      const hasTimerStartEvents: boolean = eventsRaw.some((eventRaw: any) => {
-        return eventRaw[BpmnTags.FlowElementProperty.TimerEventDefinition] !== undefined;
-      });
-
-      const hasNonTimerStartEvents: boolean = eventsRaw.some((eventRaw: any) => {
-        return eventRaw[BpmnTags.FlowElementProperty.TimerEventDefinition] === undefined;
-      });
-
-      return hasTimerStartEvents && hasNonTimerStartEvents;
-    }
-
-    return false;
-  };
-
-  const cyclicTimersAreSafe: boolean = checkIfCyclicTimersAreSafe();
-
   for (const eventRaw of eventsRaw) {
     const event: TEvent = createObjectWithCommonProperties<TEvent>(eventRaw, type);
     event.name = eventRaw.name;
     event.incoming = getModelPropertyAsArray(eventRaw, BpmnTags.FlowElementProperty.SequenceFlowIncoming);
     event.outgoing = getModelPropertyAsArray(eventRaw, BpmnTags.FlowElementProperty.SequenceFlowOutgoing);
 
-    assignEventDefinitions(event, eventRaw, cyclicTimersAreSafe);
+    assignEventDefinitions(event, eventRaw);
 
     events.push(event);
   }
@@ -172,20 +136,19 @@ function parseEventsByType<TEvent extends Model.Events.Event>(
   return events;
 }
 
-function assignEventDefinitions(event: any, eventRaw: any, ignoreCyclicTimer?: boolean): void {
+function assignEventDefinitions(event: any, eventRaw: any): void {
   assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.ErrorEventDefinition, 'errorEventDefinition');
   assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.LinkEventDefinition, 'linkEventDefinition');
   assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.MessageEventDefinition, 'messageEventDefinition');
   assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.SignalEventDefinition, 'signalEventDefinition');
   assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.TerminateEventDefinition, 'terminateEventDefinition');
-  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.TimerEventDefinition, 'timerEventDefinition', ignoreCyclicTimer);
+  assignEventDefinition(event, eventRaw, BpmnTags.FlowElementProperty.TimerEventDefinition, 'timerEventDefinition');
 }
 
 function assignEventDefinition(
   event: any, eventRaw: any,
   eventRawTagName: BpmnTags.FlowElementProperty,
   targetPropertyName: string,
-  ignoreCyclicTimer?: boolean,
 ): void {
 
   const eventDefinitonValue: any = eventRaw[eventRawTagName];
@@ -211,7 +174,6 @@ function assignEventDefinition(
       event[targetPropertyName] = getDefinitionForEvent(eventDefinitonValue.signalRef);
       break;
     case 'timerEventDefinition':
-      validateTimer(eventDefinitonValue, ignoreCyclicTimer);
       event[targetPropertyName] = eventDefinitonValue;
       break;
     default:
@@ -273,97 +235,4 @@ function getErrorById(errorId: string): Model.Types.Error {
   }
 
   return matchingError;
-}
-
-function validateTimer(rawTimerDefinition: any, ignoreCyclic: boolean): void {
-  const timerDefinitionType: TimerDefinitionType = parseTimerDefinitionType(rawTimerDefinition);
-  const timerDefinitionValue: string = parseTimerDefinitionValue(rawTimerDefinition);
-  validateTimerValue(timerDefinitionType, timerDefinitionValue, ignoreCyclic);
-}
-
-function validateTimerValue(timerType: TimerDefinitionType, timerValue: string, ignoreCyclic: boolean): void {
-  switch (timerType) {
-    case TimerDefinitionType.date:
-      const dateIsInvalid: boolean = !moment(timerValue, moment.ISO_8601).isValid();
-      if (dateIsInvalid) {
-        const errorMessage: string = `The given date definition ${timerValue} is not in ISO8601 format`;
-        throw new UnprocessableEntityError(errorMessage);
-      }
-
-      break;
-    case TimerDefinitionType.duration:
-      /**
-       * Note: Because of this Issue: https://github.com/moment/moment/issues/1805
-       * we can't really use momentjs to validate durations against the
-       * ISO8601 duration syntax.
-       *
-       * There is an isValid() method on moment.Duration objects but its
-       * useless since it always returns true.
-       */
-
-      /**
-       * Stolen from: https://stackoverflow.com/a/32045167
-       */
-       /*tslint:disable-next-line:max-line-length*/
-      const durationRegex: RegExp = /^P(?!$)(\d+(?:\.\d+)?Y)?(\d+(?:\.\d+)?M)?(\d+(?:\.\d+)?W)?(\d+(?:\.\d+)?D)?(T(?=\d)(\d+(?:\.\d+)?H)?(\d+(?:\.\d+)?M)?(\d+(?:\.\d+)?S)?)?$/gm;
-      const durationIsInvalid: boolean = !durationRegex.test(timerValue);
-
-      if (durationIsInvalid) {
-        const errorMessage: string = `The given duration definition ${timerValue} is not in ISO8601 format`;
-        throw new UnprocessableEntityError(errorMessage);
-      }
-
-      break;
-    case TimerDefinitionType.cycle:
-      /**
-       * Cyclic timers are safe, as long as there is at least one other StartEvent present.
-       */
-      if (ignoreCyclic) {
-        return;
-      }
-
-      throw new UnprocessableEntityError('Cyclic timer definitions are currently unsupported!');
-    default:
-      throw new UnprocessableEntityError('Unknown Timer definition type');
-  }
-}
-
-function parseTimerDefinitionType(eventDefinition: any): TimerDefinitionType {
-
-  const timerIsDuration: boolean = eventDefinition[TimerBpmnType.Duration] !== undefined;
-  if (timerIsDuration) {
-    return TimerDefinitionType.duration;
-  }
-
-  const timerIsCyclic: boolean = eventDefinition[TimerBpmnType.Cycle] !== undefined;
-  if (timerIsCyclic) {
-    return TimerDefinitionType.cycle;
-  }
-
-  const timerIsDate: boolean = eventDefinition[TimerBpmnType.Date] !== undefined;
-  if (timerIsDate) {
-    return TimerDefinitionType.date;
-  }
-
-  return undefined;
-}
-
-function parseTimerDefinitionValue(eventDefinition: any): string {
-
-  const timerIsDuration: boolean = eventDefinition[TimerBpmnType.Duration] !== undefined;
-  if (timerIsDuration) {
-    return eventDefinition[TimerBpmnType.Duration]._;
-  }
-
-  const timerIsCyclic: boolean = eventDefinition[TimerBpmnType.Cycle] !== undefined;
-  if (timerIsCyclic) {
-    return eventDefinition[TimerBpmnType.Cycle]._;
-  }
-
-  const timerIsDate: boolean = eventDefinition[TimerBpmnType.Date] !== undefined;
-  if (timerIsDate) {
-    return eventDefinition[TimerBpmnType.Date]._;
-  }
-
-  return undefined;
 }


### PR DESCRIPTION
**Changes:**

1. Remove all timer expression validation from the ModelParser.
    - Doing this during Model-parsing had the unfortunate side effect of preventing the use of token-expressions.
2. Implement timer validation in the TimerFacade.
3. Move all token expression functions from the FlowNodeHandlers to the TimerFacade
    - This way, token expression parsing and timer validation gets executed for all timers on all FlowNodeHandlers that use them.
4. Fix an `Unhandled Promise rejection` issue with the `IntermediateTimerEvent` handler, which could occur when an error was thrown from within the TimerFacade.
 
**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/249

PR: #245

## How can others test the changes?

Deploying a ProcessModel with a timer that uses token-based expressions should be possible again.
Also, using cyclic timers or invalid timer expressions should cause errors during ProcessModel execution.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).