### PR TITLE
♻️ Refactor expected parameters for process execution

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -65,7 +65,7 @@ function registerServices(container) {
 
   container
     .register('AutoStartService', AutoStartService)
-    .dependencies('EventAggregator','ExecuteProcessService', 'IdentityService', 'ProcessModelUseCases')
+    .dependencies('EventAggregator','ExecuteProcessService', 'ProcessModelUseCases')
     .singleton();
 
   container

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -74,6 +74,7 @@ function registerServices(container) {
       'CorrelationService',
       'EventAggregator',
       'FlowNodeHandlerFactory',
+      'IdentityService',
       'LoggingApiService',
       'MetricsApiService',
       'ProcessModelUseCases'
@@ -142,7 +143,7 @@ function registerFactories(container) {
       'IntermediateCatchEventFactory',
       'IntermediateThrowEventFactory',
       'ParallelGatewayFactory',
-      'ServiceTaskFactory',
+      'ServiceTaskFactory'
     )
     .singleton();
 }
@@ -157,7 +158,7 @@ function registerFlowNodeHandlers(container) {
       'EventAggregator',
       'FlowNodeHandlerFactory',
       'FlowNodePersistenceFacade',
-      'ResumeProcessService',
+      'ResumeProcessService'
     );
 
   container

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@process-engine/flow_node_instance.contracts": "^1.0.0",
     "@process-engine/logging_api_contracts": "^1.0.0",
     "@process-engine/metrics_api_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "feature~refactor_execute_process_parameters",
+    "@process-engine/process_engine_contracts": "^40.1.0",
     "@process-engine/process_model.contracts": "^1.0.0",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@process-engine/flow_node_instance.contracts": "^1.0.0",
     "@process-engine/logging_api_contracts": "^1.0.0",
     "@process-engine/metrics_api_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^40.0.0",
+    "@process-engine/process_engine_contracts": "feature~refactor_execute_process_parameters",
     "@process-engine/process_model.contracts": "^1.0.0",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",

--- a/src/runtime/execute_process_service.ts
+++ b/src/runtime/execute_process_service.ts
@@ -118,6 +118,8 @@ export class ExecuteProcessService implements IExecuteProcessService {
     caller?: string,
   ): Promise<EndEventReachedMessage> {
 
+    await this._validateStartRequest(identity, processModelId, startEventId);
+
     return this._startAndAwaitEndEvent(identity, processModelId, startEventId, correlationId, initialPayload, caller);
   }
 
@@ -130,6 +132,8 @@ export class ExecuteProcessService implements IExecuteProcessService {
     initialPayload?: any,
     caller?: string,
   ): Promise<EndEventReachedMessage> {
+
+    await this._validateStartRequest(identity, processModelId, startEventId, endEventId, true);
 
     return this._startAndAwaitEndEvent(identity, processModelId, startEventId, correlationId, initialPayload, caller, endEventId);
   }
@@ -147,8 +151,6 @@ export class ExecuteProcessService implements IExecuteProcessService {
     return new Promise<EndEventReachedMessage>(async(resolve: Function, reject: Function): Promise<void> => {
 
       try {
-        await this._validateStartRequest(identity, processModelId, startEventId, endEventId, true);
-
         const processInstanceConfig: IProcessInstanceConfig = await
           this._createProcessInstanceConfig(identity, processModelId, correlationId, startEventId, initialPayload, caller);
 

--- a/src/runtime/execute_process_service.ts
+++ b/src/runtime/execute_process_service.ts
@@ -3,7 +3,7 @@ import * as uuid from 'node-uuid';
 
 import {InternalServerError} from '@essential-projects/errors_ts';
 import {EventReceivedCallback, IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
-import {IIdentity} from '@essential-projects/iam_contracts';
+import {IIdentity, IIdentityService} from '@essential-projects/iam_contracts';
 
 import {ICorrelationService} from '@process-engine/correlation.contracts';
 import {ProcessToken} from '@process-engine/flow_node_instance.contracts';
@@ -46,16 +46,20 @@ export class ExecuteProcessService implements IExecuteProcessService {
 
   private readonly _eventAggregator: IEventAggregator;
   private readonly _flowNodeHandlerFactory: IFlowNodeHandlerFactory;
+  private readonly _identityService: IIdentityService;
 
   private readonly _correlationService: ICorrelationService;
   private readonly _loggingApiService: ILoggingApi;
   private readonly _metricsApiService: IMetricsApi;
   private readonly _processModelUseCases: IProcessModelUseCases;
 
+  private _internalIdentity: IIdentity;
+
   constructor(
     correlationService: ICorrelationService,
     eventAggregator: IEventAggregator,
     flowNodeHandlerFactory: IFlowNodeHandlerFactory,
+    identityService: IIdentityService,
     loggingApiService: ILoggingApi,
     metricsApiService: IMetricsApi,
     processModelUseCases: IProcessModelUseCases,
@@ -63,29 +67,35 @@ export class ExecuteProcessService implements IExecuteProcessService {
     this._correlationService = correlationService;
     this._eventAggregator = eventAggregator;
     this._flowNodeHandlerFactory = flowNodeHandlerFactory;
+    this._identityService = identityService;
     this._loggingApiService = loggingApiService;
     this._metricsApiService = metricsApiService;
     this._processModelUseCases = processModelUseCases;
   }
 
+  public async initialize(): Promise<void> {
+    const dummyToken: string = 'ZHVtbXlfdG9rZW4=';
+    this._internalIdentity = await this._identityService.getIdentity(dummyToken);
+  }
+
   public async start(
     identity: IIdentity,
-    processModel: Model.Types.Process,
+    processModelId: string,
     startEventId: string,
     correlationId: string,
     initialPayload?: any,
     caller?: string,
   ): Promise<ProcessStartedMessage> {
 
-    const processInstanceConfig: IProcessInstanceConfig =
-      this._createProcessInstanceConfig(identity, processModel, correlationId, startEventId, initialPayload, caller);
+    const processInstanceConfig: IProcessInstanceConfig = await
+      this._createProcessInstanceConfig(identity, processModelId, correlationId, startEventId, initialPayload, caller);
 
     // This UseCase is designed to resolve immediately after the ProcessInstance
     // was started, so we must not await the execution here.
     this._executeProcess(identity, processInstanceConfig);
 
     return new ProcessStartedMessage(correlationId,
-                                     processModel.id,
+                                     processModelId,
                                      processInstanceConfig.processInstanceId,
                                      startEventId,
                                      // We don't yet know the StartEvent's instanceId, because it hasn't been created yet.
@@ -97,30 +107,30 @@ export class ExecuteProcessService implements IExecuteProcessService {
 
   public async startAndAwaitEndEvent(
     identity: IIdentity,
-    processModel: Model.Types.Process,
+    processModelId: string,
     startEventId: string,
     correlationId: string,
     initialPayload?: any,
     caller?: string,
   ): Promise<EndEventReachedMessage> {
-    return this._startAndAwaitEndEvent(identity, processModel, startEventId, correlationId, initialPayload, caller);
+    return this._startAndAwaitEndEvent(identity, processModelId, startEventId, correlationId, initialPayload, caller);
   }
 
   public async startAndAwaitSpecificEndEvent(
     identity: IIdentity,
-    processModel: Model.Types.Process,
+    processModelId: string,
     startEventId: string,
     correlationId: string,
     endEventId: string,
     initialPayload?: any,
     caller?: string,
   ): Promise<EndEventReachedMessage> {
-    return this._startAndAwaitEndEvent(identity, processModel, startEventId, correlationId, initialPayload, caller, endEventId);
+    return this._startAndAwaitEndEvent(identity, processModelId, startEventId, correlationId, initialPayload, caller, endEventId);
   }
 
   private async _startAndAwaitEndEvent(
     identity: IIdentity,
-    processModel: Model.Types.Process,
+    processModelId: string,
     startEventId: string,
     correlationId: string,
     initialPayload?: any,
@@ -130,12 +140,12 @@ export class ExecuteProcessService implements IExecuteProcessService {
 
     return new Promise<EndEventReachedMessage>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      const processInstanceConfig: IProcessInstanceConfig =
-        this._createProcessInstanceConfig(identity, processModel, correlationId, startEventId, initialPayload, caller);
+      const processInstanceConfig: IProcessInstanceConfig = await
+        this._createProcessInstanceConfig(identity, processModelId, correlationId, startEventId, initialPayload, caller);
 
       const processEndMessageName: string = eventAggregatorSettings.messagePaths.endEventReached
         .replace(eventAggregatorSettings.messageParams.correlationId, processInstanceConfig.correlationId)
-        .replace(eventAggregatorSettings.messageParams.processModelId, processModel.id);
+        .replace(eventAggregatorSettings.messageParams.processModelId, processModelId);
 
       let eventSubscription: Subscription;
 
@@ -168,31 +178,36 @@ export class ExecuteProcessService implements IExecuteProcessService {
   /**
    * Creates a Set of configurations for a new ProcessInstance.
    *
-   * @param identity      The identity of the requesting user.
-   * @param processModel  The ProcessModel for wich a new ProcessInstance is to
-   *                      be created.
-   * @param correlationId The CorrelationId in which the ProcessInstance
-   *                      should run.
-   *                      Will be generated, if not provided.
-   * @param startEventId  The ID of the StartEvent by which to start the
-   *                      ProcessInstance.
-   * @param payload       The payload to pass to the ProcessInstance.
-   * @param caller        If the ProcessInstance is a Subprocess or CallActivity,
-   *                      this contains the ID of the calling ProcessInstance.
-   * @returns             A set of configurations for the new ProcessInstance.
-   *                      Contains a ProcessInstanceId, CorrelationId,
-   *                      a ProcessToken,facades for the ProcessModel and
-   *                      ProcessToken and the StartEvent that has the ID specified
-   *                      in startEventId.
+   * @async
+   * @param identity       The identity of the requesting user.
+   * @param processModelId The ID of the ProcessModel for wich a new
+   *                       ProcessInstance is to be created.
+   * @param correlationId  The CorrelationId in which the ProcessInstance
+   *                       should run.
+   *                       Will be generated, if not provided.
+   * @param startEventId   The ID of the StartEvent by which to start the
+   *                       ProcessInstance.
+   * @param payload        The payload to pass to the ProcessInstance.
+   * @param caller         If the ProcessInstance is a Subprocess or
+   *                       CallActivity, this contains the ID of the calling
+   *                       ProcessInstance.
+   * @returns              A set of configurations for the new ProcessInstance.
+   *                       Contains a ProcessInstanceId, CorrelationId,
+   *                       a ProcessToken,facades for the ProcessModel and
+   *                       ProcessToken and the StartEvent that has the ID
+   *                       specified in startEventId.
    */
-  private _createProcessInstanceConfig(
+  private async _createProcessInstanceConfig(
     identity: IIdentity,
-    processModel: Model.Types.Process,
+    processModelId: string,
     correlationId: string,
     startEventId: string,
     payload: any,
     caller: string,
-  ): IProcessInstanceConfig {
+  ): Promise<IProcessInstanceConfig> {
+
+    // We use the internal identity here to ensure the ProcessModel will be complete.
+    const processModel: Model.Types.Process = await this._processModelUseCases.getProcessModelById(this._internalIdentity, processModelId);
 
     const processModelFacade: IProcessModelFacade = new ProcessModelFacade(processModel);
 


### PR DESCRIPTION
**Changes:**

1. Add `IdentityService` to `ExecuteProcessService` dependencies.
2. The `ExecuteProcessService` no longer expects full ProcessModels, but only ProcessModelIds for its `start` methods.
    - The `ExecuteProcessService` will use our internal identity to retrieve full ProcessModels prior to execution
    - This removes the need for external services to do that themselves and guarantees that the `ExecuteProcessService` has all relevent infos at hand.
    - Note that claim checks and other security operations will already have been performed before hand by the Consumer API.
3. Remove the internal identity and the `IdentityService` from the `AutoStartService`.
    - It no longer has to query full ProcessModels, so it doesn't need that identity any more.
    - The service now only passes each ProcessModel's ID to the `ExecuteProcessService`.
4. Import logic for validation start requests from the Consumer API core. 
5. Close a time gap on the IntermediateEventHandlers, which existed between the time they were suspended and the time at which they subscribed to their events.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/253

PR: #247

## How can others test the changes?

Using the `ExecuteProcessService` will now only require external services to have a ProcessModelId at hand, instead of a full ProcessModel.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).