### PR TITLE
🔒 ♻️ Validate UserTask payloads

### DIFF
--- a/src/model/parser/event_parser.ts
+++ b/src/model/parser/event_parser.ts
@@ -201,7 +201,10 @@ function getDefinitionForEvent<TEventDefinition extends Model.Events.Definitions
  */
 function retrieveErrorObject(errorEndEventRaw: any): Model.GlobalElements.Error {
 
-  const errorIsNotAnonymous: boolean = errorEndEventRaw[BpmnTags.FlowElementProperty.ErrorEventDefinition] !== '';
+  const errorIsNotAnonymous: boolean =
+    errorEndEventRaw[BpmnTags.FlowElementProperty.ErrorEventDefinition] !== undefined &&
+    errorEndEventRaw[BpmnTags.FlowElementProperty.ErrorEventDefinition] !== null &&
+    errorEndEventRaw[BpmnTags.FlowElementProperty.ErrorEventDefinition] !== '';
 
   if (errorIsNotAnonymous) {
     const errorId: string = errorEndEventRaw[BpmnTags.FlowElementProperty.ErrorEventDefinition].errorRef;

--- a/src/runtime/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/flow_node_handler/manual_task_handler.ts
@@ -60,7 +60,8 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
       new Promise<Array<Model.Base.FlowNode>>(async(resolve: Function, reject: Function): Promise<void> => {
 
       this.onInterruptedCallback = (): void => {
-        if (this.manualTaskSubscription) {
+        const subscriptionIsActive: boolean = this.manualTaskSubscription !== undefined;
+        if (subscriptionIsActive) {
           this.eventAggregator.unsubscribe(this.manualTaskSubscription);
         }
         handlerPromise.cancel();
@@ -98,7 +99,8 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
       new Promise<Array<Model.Base.FlowNode>>(async(resolve: Function, reject: Function): Promise<void> => {
 
       this.onInterruptedCallback = (): void => {
-        if (this.manualTaskSubscription) {
+        const subscriptionIsActive: boolean = this.manualTaskSubscription !== undefined;
+        if (subscriptionIsActive) {
           this.eventAggregator.unsubscribe(this.manualTaskSubscription);
         }
         handlerPromise.cancel();

--- a/src/runtime/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/flow_node_handler/manual_task_handler.ts
@@ -45,32 +45,8 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
 
     this.logger.verbose(`Executing ManualTask instance ${this.flowNodeInstanceId}`);
     await this.persistOnEnter(token);
-    await this.persistOnSuspend(token);
 
     return this._executeHandler(token, processTokenFacade, processModelFacade, identity);
-  }
-
-  protected async _continueAfterEnter(
-    onEnterToken: ProcessToken,
-    processTokenFacade: IProcessTokenFacade,
-    processModelFacade: IProcessModelFacade,
-    identity: IIdentity,
-  ): Promise<Array<Model.Base.FlowNode>> {
-
-    await this.persistOnSuspend(onEnterToken);
-
-    return this._executeHandler(onEnterToken, processTokenFacade, processModelFacade, identity);
-  }
-
-  protected async _continueAfterSuspend(
-    flowNodeInstance: FlowNodeInstance,
-    onSuspendToken: ProcessToken,
-    processTokenFacade: IProcessTokenFacade,
-    processModelFacade: IProcessModelFacade,
-    identity: IIdentity,
-  ): Promise<Array<Model.Base.FlowNode>> {
-
-    return this._executeHandler(onSuspendToken, processTokenFacade, processModelFacade, identity);
   }
 
   protected async _executeHandler(
@@ -83,19 +59,16 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
     const handlerPromise: Promise<Array<Model.Base.FlowNode>> =
       new Promise<Array<Model.Base.FlowNode>>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      const executionPromise: Promise<any> = this._waitForManualTaskResult(identity, token);
-
       this.onInterruptedCallback = (): void => {
         if (this.manualTaskSubscription) {
           this.eventAggregator.unsubscribe(this.manualTaskSubscription);
         }
-        executionPromise.cancel();
         handlerPromise.cancel();
 
         return;
       };
 
-      const manualTaskResult: any = await executionPromise;
+      const manualTaskResult: any = await this._suspendAndWaitForManualTaskResult(identity, token);
       token.payload = manualTaskResult;
 
       await this.persistOnResume(token);
@@ -113,8 +86,71 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
     return handlerPromise;
   }
 
+  protected async _continueAfterSuspend(
+    flowNodeInstance: FlowNodeInstance,
+    onSuspendToken: ProcessToken,
+    processTokenFacade: IProcessTokenFacade,
+    processModelFacade: IProcessModelFacade,
+    identity: IIdentity,
+  ): Promise<Array<Model.Base.FlowNode>> {
+
+    const handlerPromise: Promise<Array<Model.Base.FlowNode>> =
+      new Promise<Array<Model.Base.FlowNode>>(async(resolve: Function, reject: Function): Promise<void> => {
+
+      this.onInterruptedCallback = (): void => {
+        if (this.manualTaskSubscription) {
+          this.eventAggregator.unsubscribe(this.manualTaskSubscription);
+        }
+        handlerPromise.cancel();
+
+        return;
+      };
+
+      const waitForMessagePromise: Promise<any> = await this._waitForManualTaskResult(identity, onSuspendToken);
+
+      this._sendManualTaskReachedNotification(identity, onSuspendToken);
+
+      const manualTaskResult: any = await waitForMessagePromise;
+
+      onSuspendToken.payload = manualTaskResult;
+
+      await this.persistOnResume(onSuspendToken);
+
+      processTokenFacade.addResultForFlowNode(this.manualTask.id, this.flowNodeInstanceId, manualTaskResult);
+      await this.persistOnExit(onSuspendToken);
+
+      this._sendManualTaskFinishedNotification(identity, onSuspendToken);
+
+      const nextFlowNodeInfo: Array<Model.Base.FlowNode> = processModelFacade.getNextFlowNodesFor(this.manualTask);
+
+      return resolve(nextFlowNodeInfo);
+    });
+
+    return handlerPromise;
+  }
+
   /**
-   * Suspends the current handler and waits for a FinishManualTaskMessage.
+   * Suspends the handler and waits for a FinishManualTaskMessage.
+   * Upon receiving the messsage, the handler will be resumed with the received
+   * result set.
+   *
+   * @async
+   * @param identity The identity that owns the ManualTask instance.
+   * @param token    Contains all relevant info the EventAggregator will need for
+   *                 creating the EventSubscription.
+   * @returns        The recevied ManualTask result.
+   */
+  private async _suspendAndWaitForManualTaskResult(identity: IIdentity, token: ProcessToken): Promise<any> {
+    const waitForManualTaskResultPromise: Promise<any> = this._waitForManualTaskResult(identity, token);
+    await this.persistOnSuspend(token);
+
+    this._sendManualTaskReachedNotification(identity, token);
+
+    return await waitForManualTaskResultPromise;
+  }
+
+  /**
+   * Waits for a FinishManualTaskMessage.
    * Upon receiving the messsage, the handler will be resumed.
    *
    * @async
@@ -136,8 +172,6 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
 
           resolve(manualTaskResult);
         });
-
-      this._sendManualTaskReachedNotification(identity, token);
     });
   }
 

--- a/src/runtime/flow_node_handler/manual_task_handler.ts
+++ b/src/runtime/flow_node_handler/manual_task_handler.ts
@@ -59,30 +59,30 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
     const handlerPromise: Promise<Array<Model.Base.FlowNode>> =
       new Promise<Array<Model.Base.FlowNode>>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      this.onInterruptedCallback = (): void => {
-        const subscriptionIsActive: boolean = this.manualTaskSubscription !== undefined;
-        if (subscriptionIsActive) {
-          this.eventAggregator.unsubscribe(this.manualTaskSubscription);
-        }
-        handlerPromise.cancel();
+        this.onInterruptedCallback = (): void => {
+          const subscriptionIsActive: boolean = this.manualTaskSubscription !== undefined;
+          if (subscriptionIsActive) {
+            this.eventAggregator.unsubscribe(this.manualTaskSubscription);
+          }
+          handlerPromise.cancel();
 
-        return;
-      };
+          return;
+        };
 
-      const manualTaskResult: any = await this._suspendAndWaitForManualTaskResult(identity, token);
-      token.payload = manualTaskResult;
+        const manualTaskResult: any = await this._suspendAndWaitForManualTaskResult(identity, token);
+        token.payload = manualTaskResult;
 
-      await this.persistOnResume(token);
+        await this.persistOnResume(token);
 
-      processTokenFacade.addResultForFlowNode(this.manualTask.id, this.flowNodeInstanceId, manualTaskResult);
-      await this.persistOnExit(token);
+        processTokenFacade.addResultForFlowNode(this.manualTask.id, this.flowNodeInstanceId, manualTaskResult);
+        await this.persistOnExit(token);
 
-      this._sendManualTaskFinishedNotification(identity, token);
+        this._sendManualTaskFinishedNotification(identity, token);
 
-      const nextFlowNodeInfo: Array<Model.Base.FlowNode> = processModelFacade.getNextFlowNodesFor(this.manualTask);
+        const nextFlowNodeInfo: Array<Model.Base.FlowNode> = processModelFacade.getNextFlowNodesFor(this.manualTask);
 
-      return resolve(nextFlowNodeInfo);
-    });
+        return resolve(nextFlowNodeInfo);
+      });
 
     return handlerPromise;
   }
@@ -98,35 +98,35 @@ export class ManualTaskHandler extends FlowNodeHandlerInterruptible<Model.Activi
     const handlerPromise: Promise<Array<Model.Base.FlowNode>> =
       new Promise<Array<Model.Base.FlowNode>>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      this.onInterruptedCallback = (): void => {
-        const subscriptionIsActive: boolean = this.manualTaskSubscription !== undefined;
-        if (subscriptionIsActive) {
-          this.eventAggregator.unsubscribe(this.manualTaskSubscription);
-        }
-        handlerPromise.cancel();
+        this.onInterruptedCallback = (): void => {
+          const subscriptionIsActive: boolean = this.manualTaskSubscription !== undefined;
+          if (subscriptionIsActive) {
+            this.eventAggregator.unsubscribe(this.manualTaskSubscription);
+          }
+          handlerPromise.cancel();
 
-        return;
-      };
+          return;
+        };
 
-      const waitForMessagePromise: Promise<any> = await this._waitForManualTaskResult(identity, onSuspendToken);
+        const waitForMessagePromise: Promise<any> = await this._waitForManualTaskResult(identity, onSuspendToken);
 
-      this._sendManualTaskReachedNotification(identity, onSuspendToken);
+        this._sendManualTaskReachedNotification(identity, onSuspendToken);
 
-      const manualTaskResult: any = await waitForMessagePromise;
+        const manualTaskResult: any = await waitForMessagePromise;
 
-      onSuspendToken.payload = manualTaskResult;
+        onSuspendToken.payload = manualTaskResult;
 
-      await this.persistOnResume(onSuspendToken);
+        await this.persistOnResume(onSuspendToken);
 
-      processTokenFacade.addResultForFlowNode(this.manualTask.id, this.flowNodeInstanceId, manualTaskResult);
-      await this.persistOnExit(onSuspendToken);
+        processTokenFacade.addResultForFlowNode(this.manualTask.id, this.flowNodeInstanceId, manualTaskResult);
+        await this.persistOnExit(onSuspendToken);
 
-      this._sendManualTaskFinishedNotification(identity, onSuspendToken);
+        this._sendManualTaskFinishedNotification(identity, onSuspendToken);
 
-      const nextFlowNodeInfo: Array<Model.Base.FlowNode> = processModelFacade.getNextFlowNodesFor(this.manualTask);
+        const nextFlowNodeInfo: Array<Model.Base.FlowNode> = processModelFacade.getNextFlowNodesFor(this.manualTask);
 
-      return resolve(nextFlowNodeInfo);
-    });
+        return resolve(nextFlowNodeInfo);
+      });
 
     return handlerPromise;
   }

--- a/src/runtime/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/flow_node_handler/user_task_handler.ts
@@ -119,8 +119,8 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
 
       this._sendUserTaskReachedNotification(identity, onSuspendToken);
 
-      const userTaskResult: any = await waitForMessagePromise
-      ;
+      const userTaskResult: any = await waitForMessagePromise;
+
       onSuspendToken.payload = userTaskResult;
 
       await this.persistOnResume(onSuspendToken);

--- a/src/runtime/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/flow_node_handler/user_task_handler.ts
@@ -115,7 +115,12 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
         return;
       };
 
-      const userTaskResult: any = await this._waitForUserTaskResult(identity, onSuspendToken);
+      const waitForMessagePromise: Promise<any> = this._waitForUserTaskResult(identity, onSuspendToken);
+
+      this._sendUserTaskReachedNotification(identity, onSuspendToken);
+
+      const userTaskResult: any = await waitForMessagePromise
+      ;
       onSuspendToken.payload = userTaskResult;
 
       await this.persistOnResume(onSuspendToken);
@@ -217,6 +222,8 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
     const waitForUserTaskResultPromise: Promise<any> = this._waitForUserTaskResult(identity, token);
     await this.persistOnSuspend(token);
 
+    this._sendUserTaskReachedNotification(identity, token);
+
     return await waitForUserTaskResultPromise;
   }
 
@@ -245,8 +252,6 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
 
           resolve(userTaskResult);
         });
-
-      this._sendUserTaskReachedNotification(identity, token);
     });
   }
 

--- a/src/runtime/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/flow_node_handler/user_task_handler.ts
@@ -107,35 +107,35 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
     const handlerPromise: Promise<Array<Model.Base.FlowNode>> =
       new Promise<Array<Model.Base.FlowNode>>(async(resolve: Function, reject: Function): Promise<void> => {
 
-      this.onInterruptedCallback = (): void => {
-        const subscriptionIsActive: boolean = this.userTaskSubscription !== undefined;
-        if (subscriptionIsActive) {
-          this.eventAggregator.unsubscribe(this.userTaskSubscription);
-        }
-        handlerPromise.cancel();
+        this.onInterruptedCallback = (): void => {
+          const subscriptionIsActive: boolean = this.userTaskSubscription !== undefined;
+          if (subscriptionIsActive) {
+            this.eventAggregator.unsubscribe(this.userTaskSubscription);
+          }
+          handlerPromise.cancel();
 
-        return;
-      };
+          return;
+        };
 
-      const waitForMessagePromise: Promise<any> = this._waitForUserTaskResult(identity, onSuspendToken);
+        const waitForMessagePromise: Promise<any> = this._waitForUserTaskResult(identity, onSuspendToken);
 
-      this._sendUserTaskReachedNotification(identity, onSuspendToken);
+        this._sendUserTaskReachedNotification(identity, onSuspendToken);
 
-      const userTaskResult: any = await waitForMessagePromise;
+        const userTaskResult: any = await waitForMessagePromise;
 
-      onSuspendToken.payload = userTaskResult;
+        onSuspendToken.payload = userTaskResult;
 
-      await this.persistOnResume(onSuspendToken);
+        await this.persistOnResume(onSuspendToken);
 
-      processTokenFacade.addResultForFlowNode(this.userTask.id, this.flowNodeInstanceId, userTaskResult);
-      await this.persistOnExit(onSuspendToken);
+        processTokenFacade.addResultForFlowNode(this.userTask.id, this.flowNodeInstanceId, userTaskResult);
+        await this.persistOnExit(onSuspendToken);
 
-      this._sendUserTaskFinishedNotification(identity, onSuspendToken);
+        this._sendUserTaskFinishedNotification(identity, onSuspendToken);
 
-      const nextFlowNodeInfo: Array<Model.Base.FlowNode> = processModelFacade.getNextFlowNodesFor(this.userTask);
+        const nextFlowNodeInfo: Array<Model.Base.FlowNode> = processModelFacade.getNextFlowNodesFor(this.userTask);
 
-      return resolve(nextFlowNodeInfo);
-    });
+        return resolve(nextFlowNodeInfo);
+      });
 
     return handlerPromise;
   }
@@ -178,8 +178,6 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
   private _validateExpression(expression: string, token: any): void {
 
     try {
-      let result: string = expression;
-
       if (!expression) {
         return;
       }
@@ -198,10 +196,7 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
       const functionString: string = `return ${expressionBody}`;
       const scriptFunction: Function = new Function('token', functionString);
 
-      result = scriptFunction.call(token, token);
-      result = result === undefined ? null : result;
-
-      return;
+      scriptFunction.call(token, token);
     } catch (error) {
       const errorMsg: string = `Cannot evaluate expression ${expression}! The ProcessToken is missing some required properties!`;
       this.logger.error(errorMsg);

--- a/src/runtime/flow_node_handler/user_task_handler.ts
+++ b/src/runtime/flow_node_handler/user_task_handler.ts
@@ -64,7 +64,8 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
           this._validateUserTaskFormFieldConfigurations(token, processTokenFacade);
 
           this.onInterruptedCallback = (): void => {
-            if (this.userTaskSubscription) {
+            const subscriptionIsActive: boolean = this.userTaskSubscription !== undefined;
+            if (subscriptionIsActive) {
               this.eventAggregator.unsubscribe(this.userTaskSubscription);
             }
             handlerPromise.cancel();
@@ -107,7 +108,8 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
       new Promise<Array<Model.Base.FlowNode>>(async(resolve: Function, reject: Function): Promise<void> => {
 
       this.onInterruptedCallback = (): void => {
-        if (this.userTaskSubscription) {
+        const subscriptionIsActive: boolean = this.userTaskSubscription !== undefined;
+        if (subscriptionIsActive) {
           this.eventAggregator.unsubscribe(this.userTaskSubscription);
         }
         handlerPromise.cancel();
@@ -203,6 +205,7 @@ export class UserTaskHandler extends FlowNodeHandlerInterruptible<Model.Activiti
     } catch (error) {
       const errorMsg: string = `Cannot evaluate expression ${expression}! The ProcessToken is missing some required properties!`;
       this.logger.error(errorMsg);
+
       throw new InternalServerError(errorMsg);
     }
   }


### PR DESCRIPTION
**Changes:**

1. Fix an issue which caused ManualTasks and UserTasks to be suspended before they had created their subscriptions on the EventAggregator.
    - This could lead to situations, where a UserTaskHandler missed a `FinishUserTask` notification and remained suspended indefinitely.
2. Add validation for a UserTask's FormField expressions, to ensure a FormField doesn't attempt to use non-existing token values.
3. Fix ErrorEventDefinition parsing.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/240
Part of https://github.com/process-engine/process_engine_runtime/issues/263

PR: #251

## How can others test the changes?

Try executing a UserTask with a FormField, which tries accesing non-existing token values (like `${token.a.b.c.whatever}`).

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).