### PR TITLE
♻️ Use ExecuteProcessService to run CallActivities

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -65,7 +65,7 @@ function registerServices(container) {
 
   container
     .register('AutoStartService', AutoStartService)
-    .dependencies('EventAggregator','ExecuteProcessService', 'ProcessModelUseCases')
+    .dependencies('EventAggregator', 'ExecuteProcessService', 'ProcessModelUseCases')
     .singleton();
 
   container
@@ -153,11 +153,12 @@ function registerFlowNodeHandlers(container) {
   container
     .register('CallActivityHandler', CallActivityHandler)
     .dependencies(
-      'ConsumerApiService',
       'CorrelationService',
       'EventAggregator',
+      'ExecuteProcessService',
       'FlowNodeHandlerFactory',
       'FlowNodePersistenceFacade',
+      'ProcessModelUseCases',
       'ResumeProcessService'
     );
 
@@ -227,7 +228,7 @@ function registerFlowNodeHandlers(container) {
 
   container
     .register('InternalServiceTaskHandler', InternalServiceTaskHandler)
-    .dependencies('container','EventAggregator', 'FlowNodeHandlerFactory', 'FlowNodePersistenceFacade');
+    .dependencies('container', 'EventAggregator', 'FlowNodeHandlerFactory', 'FlowNodePersistenceFacade');
 
   container
     .register('StartEventHandler', StartEventHandler)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "12.0.1",
+  "version": "12.1.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/timing_contracts": "^4.0.0",
     "@process-engine/external_task_api_contracts": "^1.0.0",
-    "@process-engine/consumer_api_contracts": "^5.0.0",
     "@process-engine/correlation.contracts": "^1.0.2",
     "@process-engine/flow_node_instance.contracts": "^1.0.0",
     "@process-engine/logging_api_contracts": "^1.0.0",


### PR DESCRIPTION
**Changes:**

CallActivities are no longer run through the ConsumerAPI, but directly through the ExecuteProcessService.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/277

PR: #254

## How can others test the changes?

This is an internal refactoring, so everything should run as before.
Maybe a little faster, now that we don't have to run all the way through the Consumer API to run CallActivities.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).