### PR TITLE
✨ Add EndEvent name and ID to CallActivity result

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -87,6 +87,7 @@ function registerServices(container) {
     .dependencies(
       'BpmnModelParser',
       'CorrelationService',
+      'EventAggregator',
       'FlowNodeHandlerFactory',
       'FlowNodeInstanceService',
       'LoggingApiService',

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@process-engine/flow_node_instance.contracts": "^1.1.0",
     "@process-engine/logging_api_contracts": "^1.0.0",
     "@process-engine/metrics_api_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^41.1.0",
+    "@process-engine/process_engine_contracts": "feature~add_event_name_and_id_to_call_activity_result",
     "@process-engine/process_model.contracts": "^2.1.0",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@process-engine/flow_node_instance.contracts": "^1.1.0",
     "@process-engine/logging_api_contracts": "^1.0.0",
     "@process-engine/metrics_api_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "feature~add_event_name_and_id_to_call_activity_result",
+    "@process-engine/process_engine_contracts": "41.2.0-da1bd55a-b171",
     "@process-engine/process_model.contracts": "^2.1.0",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",

--- a/src/runtime/execute_process_service.ts
+++ b/src/runtime/execute_process_service.ts
@@ -171,8 +171,7 @@ export class ExecuteProcessService implements IExecuteProcessService {
 
         await this._executeProcess(identity, processInstanceConfig);
       } catch (error) {
-        // Errors thrown by an ErrorEndEvent ("error.errorCode")
-        // and @essential-project errors ("error.code") are thrown as they are.
+        // Errors from @essential-project and ErrorEndEvents are thrown as they are.
         // Everything else is thrown as an InternalServerError.
         const isPresetError: boolean = (error.errorCode || error.code) && error.name;
         if (isPresetError) {
@@ -289,12 +288,7 @@ export class ExecuteProcessService implements IExecuteProcessService {
 
     const startEventIdSpecified: boolean = startEventId !== undefined;
 
-    /**
-     * If the user specified a StartEventId, we want to explicitly look that up.
-     * If not, we assume that the Process only contains one StartEvent.
-     */
-    const startEvent: Model.Events.StartEvent =
-      startEventIdSpecified
+    const startEvent: Model.Events.StartEvent = startEventIdSpecified
         ? processModelFacade.getStartEventById(startEventId)
         : processModelFacade.getSingleStartEvent();
 
@@ -475,7 +469,7 @@ export class ExecuteProcessService implements IExecuteProcessService {
       processInstanceConfig.processModelId,
       processInstanceConfig.processInstanceId,
       resultToken.flowNodeId,
-      undefined, // TODO: Add FlowNodeInstanceId to final result token.
+      resultToken.flowNodeInstanceId,
       identity,
       resultToken.result);
 

--- a/src/runtime/flow_node_handler/end_event_handler.ts
+++ b/src/runtime/flow_node_handler/end_event_handler.ts
@@ -188,7 +188,8 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
                                                                                          this.endEvent.id,
                                                                                          this.flowNodeInstanceId,
                                                                                          identity,
-                                                                                         token.payload);
+                                                                                         token.payload,
+                                                                                         this.endEvent.id);
     // ProcessInstance specific notification
     this.eventAggregator.publish(eventName, message);
     // Global notification
@@ -214,7 +215,8 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
                                                                        this.endEvent.id,
                                                                        this.flowNodeInstanceId,
                                                                        identity,
-                                                                       token.payload);
+                                                                       token.payload,
+                                                                       this.endEvent.id);
     // ProcessInstance specific notification
     this.eventAggregator.publish(processEndMessageName, message);
     // Global notification

--- a/src/runtime/flow_node_handler/end_event_handler.ts
+++ b/src/runtime/flow_node_handler/end_event_handler.ts
@@ -128,7 +128,8 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
                                                                                this.endEvent.id,
                                                                                this.flowNodeInstanceId,
                                                                                identity,
-                                                                               token.payload);
+                                                                               token.payload,
+                                                                               this.endEvent.name);
     // Message-specific notification
     this.eventAggregator.publish(eventName, message);
     // General message notification
@@ -159,7 +160,8 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
                                                                              this.endEvent.id,
                                                                              this.flowNodeInstanceId,
                                                                              identity,
-                                                                             token.payload);
+                                                                             token.payload,
+                                                                             this.endEvent.name);
     // Signal-specific notification
     this.eventAggregator.publish(eventName, message);
     // General signal notification
@@ -189,7 +191,7 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
                                                                                          this.flowNodeInstanceId,
                                                                                          identity,
                                                                                          token.payload,
-                                                                                         this.endEvent.id);
+                                                                                         this.endEvent.name);
     // ProcessInstance specific notification
     this.eventAggregator.publish(eventName, message);
     // Global notification
@@ -216,7 +218,7 @@ export class EndEventHandler extends FlowNodeHandler<Model.Events.EndEvent> {
                                                                        this.flowNodeInstanceId,
                                                                        identity,
                                                                        token.payload,
-                                                                       this.endEvent.id);
+                                                                       this.endEvent.name);
     // ProcessInstance specific notification
     this.eventAggregator.publish(processEndMessageName, message);
     // Global notification


### PR DESCRIPTION
**Changes:**

1. Provide the FlowNodeId with messages send by EndEvents.
2. Include `EndEventId` and `EndEventName` in each CallActivity result token.
3. Provide FlowNodeInstanceId with `ProcessInstanceFinished` notifications
4. Add missing notifications to the `ResumeProcess` workflow
5. Ensure that the `ResumeProcessService` always returns the final result for each ProcessInstance it resumes.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/280

PR: #255

## How can others test the changes?

Use the new messages to send notifications for EndEvents.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).