### PR TITLE
🐛 Add missing persistOnError call to external ServiceTask handler

### DIFF
--- a/src/runtime/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -68,6 +68,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
 
         if (error) {
           this.logger.error(`External processing of ServiceTask failed!`, error);
+          onSuspendToken.payload = error;
           await this.persistOnError(onSuspendToken, error);
 
           return reject(error);
@@ -195,6 +196,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
 
           if (error) {
             this.logger.error(`The external worker failed to process the ExternalTask!`, error);
+            token.payload = error;
             await this.persistOnError(token, error);
 
             return reject(error);

--- a/src/runtime/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -70,7 +70,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
           this.logger.error(`External processing of ServiceTask failed!`, error);
           await this.persistOnError(onSuspendToken, error);
 
-          throw error;
+          return reject(error);
         }
 
         this.logger.verbose('External processing of the ServiceTask finished successfully.');

--- a/src/runtime/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -195,6 +195,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
 
           if (error) {
             this.logger.error(`The external worker failed to process the ExternalTask!`, error);
+            await this.persistOnError(token, error);
 
             return reject(error);
           }


### PR DESCRIPTION
**Changes:**

1. Add a missing `persistOnError` call to the external ServiceTask handler.
2. Fix Promise-rejection in external ServiceTask resumption.
3. Update token payload prior to `persistOnError` call.

PR: #267 

## How can others test the changes?

- Start a process that uses a ServiceTask with an "external" configuration
- Use a worker to finish that ExternalTask with an error
- The ServiceTask that uses this ExternalTask should now be finished with an error as well.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).