### PR TITLE
🐛 Fix error deserialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/process_engine_core#readme",
   "dependencies": {
-    "@essential-projects/errors_ts": "^1.4.0",
+    "@essential-projects/errors_ts": "feature~fix_error_serialization",
     "@essential-projects/timing_contracts": "^4.0.0",
     "@process-engine/external_task_api_contracts": "^1.0.0",
     "@process-engine/correlation.contracts": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/process_engine_core#readme",
   "dependencies": {
-    "@essential-projects/errors_ts": "feature~fix_error_serialization",
+    "@essential-projects/errors_ts": "^1.4.5",
     "@essential-projects/timing_contracts": "^4.0.0",
     "@process-engine/external_task_api_contracts": "^1.0.0",
     "@process-engine/correlation.contracts": "^1.0.2",

--- a/src/runtime/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -68,7 +68,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
 
         if (error) {
           this.logger.error(`External processing of ServiceTask failed!`, error);
-          onSuspendToken.payload = error;
+          onSuspendToken.payload = error.message;
           await this.persistOnError(onSuspendToken, error);
 
           return reject(error);
@@ -196,7 +196,7 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
 
           if (error) {
             this.logger.error(`The external worker failed to process the ExternalTask!`, error);
-            token.payload = error;
+            token.payload = error.message;
             await this.persistOnError(token, error);
 
             return reject(error);

--- a/src/runtime/flow_node_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/flow_node_handler/service_task_handlers/external_service_task_handler.ts
@@ -1,6 +1,6 @@
 import {Logger} from 'loggerhythm';
 
-import {InternalServerError} from '@essential-projects/errors_ts';
+import {BaseError, InternalServerError} from '@essential-projects/errors_ts';
 import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
@@ -68,7 +68,10 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
 
         if (error) {
           this.logger.error(`External processing of ServiceTask failed!`, error);
-          onSuspendToken.payload = error.message;
+          onSuspendToken.payload = {
+            errorMessage: error.message,
+            errorCode: (error as BaseError).code,
+          };
           await this.persistOnError(onSuspendToken, error);
 
           return reject(error);
@@ -196,7 +199,10 @@ export class ExternalServiceTaskHandler extends FlowNodeHandlerInterruptible<Mod
 
           if (error) {
             this.logger.error(`The external worker failed to process the ExternalTask!`, error);
-            token.payload = error.message;
+            token.payload = {
+              errorMessage: error.message,
+              errorCode: (error as BaseError).code,
+            };
             await this.persistOnError(token, error);
 
             return reject(error);


### PR DESCRIPTION
**Changes:**

Only use an error's code and message for the external ServiceTask's `persistOnError` token, for easier usability.
The FlowNodeInstance already gets the full error, so there's no need to duplicate things.

Besides, stuff like call-stacks are technical information anyway and shouldn't be part of the token.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/309

PR: #268

## How can others test the changes?

When an ExternalTask is finished with an error, the corresponding ServiceTask gets the errors message and code as token payload.
The full error is stored with the FlowNodeInstance itself.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).