### PR TITLE
🐛 Fix timer start event handling

### DIFF
--- a/src/runtime/facades/timer_facade.ts
+++ b/src/runtime/facades/timer_facade.ts
@@ -109,6 +109,8 @@ export class TimerFacade implements ITimerFacade {
 
   private startCycleTimer(timerDefinition: string, timerCallback: Function, callbackEventName: string): Subscription {
 
+    logger.verbose(`Starting new cyclic timer with definition ${timerDefinition} and event name ${callbackEventName}`);
+
     const duration = moment.duration(timerDefinition);
 
     const timingRule: TimerRule = {
@@ -120,8 +122,9 @@ export class TimerFacade implements ITimerFacade {
       second: duration.seconds(),
     };
 
-    const subscription = this.eventAggregator.subscribe(callbackEventName, (): void => {
-      timerCallback();
+    const subscription = this.eventAggregator.subscribe(callbackEventName, (eventPayload, eventName): void => {
+      logger.verbose(`Cyclic timer ${eventName} has expired. Executing callback.`);
+      timerCallback(eventPayload);
     });
 
     this.timerService.periodic(timingRule, callbackEventName);
@@ -131,11 +134,14 @@ export class TimerFacade implements ITimerFacade {
 
   private startDurationTimer(timerDefinition: string, timerCallback: Function, callbackEventName: string): Subscription {
 
+    logger.verbose(`Starting new duration timer with definition ${timerDefinition} and event name ${callbackEventName}`);
+
     const duration = moment.duration(timerDefinition);
     const date = moment().add(duration);
 
-    const subscription = this.eventAggregator.subscribeOnce(callbackEventName, (): void => {
-      timerCallback();
+    const subscription = this.eventAggregator.subscribeOnce(callbackEventName, (eventPayload, eventName): void => {
+      logger.verbose(`Duration timer ${eventName} has expired. Executing callback.`);
+      timerCallback(eventPayload);
     });
 
     this.timerService.once(date, callbackEventName);
@@ -145,10 +151,13 @@ export class TimerFacade implements ITimerFacade {
 
   private startDateTimer(timerDefinition: string, timerCallback: Function, callbackEventName: string): Subscription {
 
+    logger.verbose(`Starting new date timer with definition ${timerDefinition} and event name ${callbackEventName}`);
+
     const date = moment(timerDefinition);
 
-    const subscription = this.eventAggregator.subscribeOnce(callbackEventName, (): void => {
-      timerCallback();
+    const subscription = this.eventAggregator.subscribeOnce(callbackEventName, (eventPayload, eventName): void => {
+      logger.verbose(`Date timer ${eventName} has expired. Executing callback.`);
+      timerCallback(eventPayload);
     });
 
     this.timerService.once(date, callbackEventName);

--- a/src/runtime/facades/timer_facade.ts
+++ b/src/runtime/facades/timer_facade.ts
@@ -181,11 +181,20 @@ export class TimerFacade implements ITimerFacade {
 
     switch (timerType) {
       case TimerDefinitionType.date:
-        const dateIsInvalid = !moment(timerValue, moment.ISO_8601).isValid();
+        const dateIsInvalid = !moment(timerValue, moment.ISO_8601, true).isValid();
         if (dateIsInvalid) {
-          const invalidDateMessage = `The given date definition ${timerValue} is not in ISO8601 format`;
+          const invalidDateMessage = `The given date definition ${timerValue} is not in ISO8601 format!`;
           logger.error(invalidDateMessage);
           throw new UnprocessableEntityError(invalidDateMessage);
+        }
+
+        const now = moment();
+
+        const dateIsPast = moment(timerValue).isBefore(now);
+        if (dateIsPast) {
+          const dateIsPastErrorMessage = `The given date definition ${timerValue} is in the past!`;
+          logger.error(dateIsPastErrorMessage);
+          throw new UnprocessableEntityError(dateIsPastErrorMessage);
         }
 
         break;

--- a/src/runtime/flow_node_handler/event_handler/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/intermediate_timer_catch_event_handler.ts
@@ -66,8 +66,6 @@ export class IntermediateTimerCatchEventHandler extends EventHandler<Model.Event
           processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, this.flowNodeInstanceId, interruptionToken);
 
           handlerPromise.cancel();
-
-          return undefined;
         };
 
         await this.suspendAndExecuteTimer(token, processTokenFacade);
@@ -81,6 +79,7 @@ export class IntermediateTimerCatchEventHandler extends EventHandler<Model.Event
 
         return resolve(nextFlowNodeInfo);
       } catch (error) {
+        await this.persistOnError(token, error);
         return reject(error);
       }
     });
@@ -107,8 +106,6 @@ export class IntermediateTimerCatchEventHandler extends EventHandler<Model.Event
           processTokenFacade.addResultForFlowNode(this.timerCatchEvent.id, this.flowNodeInstanceId, interruptionToken);
 
           handlerPromise.cancel();
-
-          return undefined;
         };
 
         await this.executeTimer(processTokenFacade);
@@ -122,6 +119,7 @@ export class IntermediateTimerCatchEventHandler extends EventHandler<Model.Event
 
         return resolve(nextFlowNodeInfo);
       } catch (error) {
+        await this.persistOnError(onSuspendToken, error);
         return reject(error);
       }
     });

--- a/src/runtime/flow_node_handler/event_handler/start_event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/start_event_handler.ts
@@ -166,7 +166,9 @@ export class StartEventHandler extends EventHandler<Model.Events.StartEvent> {
   private async suspendAndWaitForTimerToElapse(currentToken: ProcessToken, processTokenFacade: IProcessTokenFacade): Promise<any> {
     return new Promise<any>(async (resolve: Function, reject: Function): Promise<void> => {
       try {
+        this.logger.verbose('Initializing Timer');
         this.waitForTimerToElapse(currentToken, processTokenFacade, resolve);
+        this.logger.verbose('Suspending activity until timer expires');
         await this.persistOnSuspend(currentToken);
       } catch (error) {
         reject(error);
@@ -179,6 +181,7 @@ export class StartEventHandler extends EventHandler<Model.Events.StartEvent> {
     const timerDefinition = this.startEvent.timerEventDefinition;
 
     const timerElapsed = (): void => {
+      this.logger.verbose('Timer has expired, continuing execution');
       // TODO: Can't handle cyclic timers yet, so we always need to clean this up for now.
       this.timerFacade.cancelTimerSubscription(this.timerSubscription);
 

--- a/src/runtime/flow_node_handler/event_handler/start_event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/start_event_handler.ts
@@ -11,7 +11,6 @@ import {
   IProcessTokenFacade,
   ITimerFacade,
   ProcessStartedMessage,
-  TimerDefinitionType,
   eventAggregatorSettings,
 } from '@process-engine/process_engine_contracts';
 import {Model} from '@process-engine/process_model.contracts';
@@ -21,6 +20,7 @@ import {EventHandler} from './index';
 export class StartEventHandler extends EventHandler<Model.Events.StartEvent> {
 
   private timerFacade: ITimerFacade;
+  private timerSubscription: Subscription;
 
   constructor(
     eventAggregator: IEventAggregator,
@@ -58,19 +58,42 @@ export class StartEventHandler extends EventHandler<Model.Events.StartEvent> {
     processModelFacade: IProcessModelFacade,
   ): Promise<Array<Model.Base.FlowNode>> {
 
-    // Only TimerStartEvents are suspendable, so no check is required here.
-    const newTokenPayload =
-      await new Promise<any>(async (resolve: Function, reject: Function): Promise<void> => {
-        this.waitForTimerToElapse(onSuspendToken, resolve);
-      });
+    const handlerPromise = new Promise<Array<Model.Base.FlowNode>>(async (resolve: Function, reject: Function): Promise<void> => {
 
-    onSuspendToken.payload = newTokenPayload;
-    await this.persistOnResume(onSuspendToken);
+      try {
+        this.onInterruptedCallback = (interruptionToken: ProcessToken): void => {
 
-    processTokenFacade.addResultForFlowNode(this.startEvent.id, this.flowNodeInstanceId, onSuspendToken.payload);
-    await this.persistOnExit(onSuspendToken);
+          if (this.timerSubscription) {
+            this.timerFacade.cancelTimerSubscription(this.timerSubscription);
+          }
 
-    return processModelFacade.getNextFlowNodesFor(this.startEvent);
+          processTokenFacade.addResultForFlowNode(this.startEvent.id, this.flowNodeInstanceId, interruptionToken);
+
+          handlerPromise.cancel();
+        };
+
+        // Only TimerStartEvents are suspendable, so no check is required here.
+        const newTokenPayload =
+          await new Promise<any>(async (timerResolve: Function): Promise<void> => {
+            this.waitForTimerToElapse(onSuspendToken, processTokenFacade, timerResolve);
+          });
+
+        onSuspendToken.payload = newTokenPayload;
+        await this.persistOnResume(onSuspendToken);
+
+        processTokenFacade.addResultForFlowNode(this.startEvent.id, this.flowNodeInstanceId, onSuspendToken.payload);
+        await this.persistOnExit(onSuspendToken);
+
+        const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.startEvent);
+
+        return resolve(nextFlowNodeInfo);
+      } catch (error) {
+        await this.persistOnError(onSuspendToken, error);
+        return reject(error);
+      }
+    });
+
+    return handlerPromise;
   }
 
   protected async executeHandler(
@@ -80,30 +103,46 @@ export class StartEventHandler extends EventHandler<Model.Events.StartEvent> {
     identity: IIdentity,
   ): Promise<Array<Model.Base.FlowNode>> {
 
-    this.sendProcessStartedMessage(identity, token, this.startEvent.id);
+    const handlerPromise = new Promise<Array<Model.Base.FlowNode>>(async (resolve: Function, reject: Function): Promise<void> => {
 
-    const flowNodeIsTimerStartEvent = this.startEvent.timerEventDefinition !== undefined;
+      try {
+        this.onInterruptedCallback = (interruptionToken: ProcessToken): void => {
 
-    // TimerStartEvents cannot be auto-started yet and must be handled manually here.
-    if (flowNodeIsTimerStartEvent) {
-      const newTokenPayload = await this.suspendAndWaitForTimerToElapse(token);
-      token.payload = newTokenPayload;
-      await this.persistOnResume(token);
-    }
+          if (this.timerSubscription) {
+            this.timerFacade.cancelTimerSubscription(this.timerSubscription);
+          }
 
-    processTokenFacade.addResultForFlowNode(this.startEvent.id, this.flowNodeInstanceId, token.payload);
-    await this.persistOnExit(token);
+          processTokenFacade.addResultForFlowNode(this.startEvent.id, this.flowNodeInstanceId, interruptionToken);
 
-    return processModelFacade.getNextFlowNodesFor(this.startEvent);
+          handlerPromise.cancel();
+        };
+
+        this.sendProcessStartedMessage(identity, token, this.startEvent.id);
+
+        const flowNodeIsTimerStartEvent = this.startEvent.timerEventDefinition !== undefined;
+
+        // TimerStartEvents cannot be auto-started yet and must be handled manually here.
+        if (flowNodeIsTimerStartEvent) {
+          const newTokenPayload = await this.suspendAndWaitForTimerToElapse(token, processTokenFacade);
+          token.payload = newTokenPayload;
+          await this.persistOnResume(token);
+        }
+
+        processTokenFacade.addResultForFlowNode(this.startEvent.id, this.flowNodeInstanceId, token.payload);
+        await this.persistOnExit(token);
+
+        const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.startEvent);
+
+        return resolve(nextFlowNodeInfo);
+      } catch (error) {
+        await this.persistOnError(token, error);
+        return reject(error);
+      }
+    });
+
+    return handlerPromise;
   }
 
-  /**
-   * Sends a message that the ProcessInstance was started.
-   *
-   * @param identity     The identity that owns the StartEvent instance.
-   * @param token        Current token object, which contains all necessary Process Metadata.
-   * @param startEventId Id of the used StartEvent.
-   */
   private sendProcessStartedMessage(identity: IIdentity, token: ProcessToken, startEventId: string): void {
     const processStartedMessage = new ProcessStartedMessage(
       token.correlationId,
@@ -124,40 +163,29 @@ export class StartEventHandler extends EventHandler<Model.Events.StartEvent> {
     this.eventAggregator.publish(processWithIdStartedMessage, processStartedMessage);
   }
 
-  private async suspendAndWaitForTimerToElapse(currentToken: ProcessToken): Promise<any> {
+  private async suspendAndWaitForTimerToElapse(currentToken: ProcessToken, processTokenFacade: IProcessTokenFacade): Promise<any> {
     return new Promise<any>(async (resolve: Function, reject: Function): Promise<void> => {
-      this.waitForTimerToElapse(currentToken, resolve);
-      await this.persistOnSuspend(currentToken);
+      try {
+        this.waitForTimerToElapse(currentToken, processTokenFacade, resolve);
+        await this.persistOnSuspend(currentToken);
+      } catch (error) {
+        reject(error);
+      }
     });
   }
 
-  /**
-   * If a timed StartEvent is used, this will delay the events execution
-   * until the timer has elapsed.
-   *
-   * @param currentToken The current ProcessToken.
-   * @param resolveFunc  The function to call after the timer has elapsed.
-   */
-  private waitForTimerToElapse(currentToken: ProcessToken, resolveFunc: Function): void {
+  private waitForTimerToElapse(currentToken: ProcessToken, processTokenFacade: IProcessTokenFacade, resolveFunc: Function): void {
 
     const timerDefinition = this.startEvent.timerEventDefinition;
 
-    let timerSubscription: Subscription;
-
-    const timerType = this.timerFacade.parseTimerDefinitionType(timerDefinition);
-    const timerValue = this.timerFacade.parseTimerDefinitionValue(timerDefinition);
-
     const timerElapsed = (): void => {
-
-      const cancelSubscription = timerSubscription && timerType !== TimerDefinitionType.cycle;
-      if (cancelSubscription) {
-        this.eventAggregator.unsubscribe(timerSubscription);
-      }
+      // TODO: Can't handle cyclic timers yet, so we always need to clean this up for now.
+      this.timerFacade.cancelTimerSubscription(this.timerSubscription);
 
       resolveFunc(currentToken.payload);
     };
 
-    timerSubscription = this.timerFacade.initializeTimer(this.startEvent, timerType, timerValue, timerElapsed);
+    this.timerSubscription = this.timerFacade.initializeTimerFromDefinition(this.startEvent, timerDefinition, processTokenFacade, timerElapsed);
   }
 
 }


### PR DESCRIPTION
## Changes

1. Add missing `onError` state persistence to `IntermediateTimerCatchEvents`
2. Add interruption support to `StartEvent` handler; ProcessInstances that get stuck at a TimerStartEvent can now be stopped
    - This is achieved by cancelling the Promise that contains the handlers execution.
3. Prevent the use of past dates with Date-type timer events
4. Throw an error when attempting to use cyclic timers with TimerStartEvents; these are not supported yet
5. Add verbose logging to the TimerFacade

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/330

PR: #272

## How to test the changes

Best use BPMN Studio for this.

- Start a ProcessInstance that starts with a TimerStartEvent
    - An error will be thrown, if a cyclic timer, or a past date is used
- Try stopping the the ProcessInstance
- The ProcessInstance will now be aborted as expected