### PR TITLE
✨ Trigger TimerEvents with past date values immediately

### DIFF
--- a/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
@@ -48,6 +48,10 @@ export class TimerBoundaryEventHandler extends BoundaryEventHandler {
 
       this.logger.verbose(`TimerBoundaryEvent for ProcessModel ${token.processModelId} in ProcessInstance ${token.processInstanceId} was triggered.`);
 
+      if (this.timerSubscription && this.timerSubscription.onlyReceiveOnce === false) {
+        this.timerFacade.cancelTimerSubscription(this.timerSubscription);
+      }
+
       const nextFlowNode = this.getNextFlowNode(processModelFacade);
 
       const eventData = {

--- a/src/runtime/flow_node_handler/event_handler/intermediate_timer_catch_event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/intermediate_timer_catch_event_handler.ts
@@ -139,8 +139,9 @@ export class IntermediateTimerCatchEventHandler extends EventHandler<Model.Event
     return new Promise<void>(async (resolve: Function, reject: Function): Promise<void> => {
       try {
         const timerElapsed = (): void => {
-          // TODO: Can't handle cyclic timers yet, so we always need to clean this up for now.
-          this.timerFacade.cancelTimerSubscription(this.timerSubscription);
+          if (this.timerSubscription && this.timerSubscription.onlyReceiveOnce === false) {
+            this.timerFacade.cancelTimerSubscription(this.timerSubscription);
+          }
           resolve();
         };
 

--- a/src/runtime/flow_node_handler/event_handler/start_event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/start_event_handler.ts
@@ -181,8 +181,9 @@ export class StartEventHandler extends EventHandler<Model.Events.StartEvent> {
 
     const timerElapsed = (): void => {
       this.logger.verbose('Timer has expired, continuing execution');
-      // TODO: Can't handle cyclic timers yet, so we always need to clean this up for now.
-      this.timerFacade.cancelTimerSubscription(this.timerSubscription);
+      if (this.timerSubscription && this.timerSubscription.onlyReceiveOnce === false) {
+        this.timerFacade.cancelTimerSubscription(this.timerSubscription);
+      }
 
       resolveFunc(currentToken.payload);
     };


### PR DESCRIPTION
## Changes

1. Immediately start TimerEvents that use a date-type timer with a past date as value.
2. Robustify timer disposal for each handler that uses them. 

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/337

PR: #274

## How to test the changes

See [here](https://github.com/process-engine/process_engine_runtime/pull/339).
