### PR TITLE
🐛 Fix resumption of FlowNodes with multiple FlowNodeInstances

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@process-engine/flow_node_instance.contracts": "^2.0.0",
     "@process-engine/logging_api_contracts": "^1.0.0",
     "@process-engine/metrics_api_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "feature~fix_resumption_for_flow_nodes_with_multiple_instances",
+    "@process-engine/process_engine_contracts": "44.0.0-b333bfe0-b6",
     "@process-engine/process_model.contracts": "^2.3.0",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@process-engine/flow_node_instance.contracts": "^2.0.0",
     "@process-engine/logging_api_contracts": "^1.0.0",
     "@process-engine/metrics_api_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^43.3.0",
+    "@process-engine/process_engine_contracts": "feature~fix_resumption_for_flow_nodes_with_multiple_instances",
     "@process-engine/process_model.contracts": "^2.3.0",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "12.7.0",
+  "version": "12.8.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -198,7 +198,9 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
             const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);
 
-            processTokenForBranch.flowNodeInstanceId = nextFlowNodeInstance.id || nextFlowNodeHandler.getInstanceId();
+            processTokenForBranch.flowNodeInstanceId = nextFlowNodeInstance
+              ? nextFlowNodeInstance.id
+              : nextFlowNodeHandler.getInstanceId();
 
             // An instance for the next FlowNode has already been created. Continue resuming
             if (nextFlowNodeInstance) {

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -99,7 +99,8 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
   }
 
   public async resume(
-    flowNodeInstances: Array<FlowNodeInstance>,
+    flowNodeInstanceForHandler: FlowNodeInstance,
+    allFlowNodeInstances: Array<FlowNodeInstance>,
     processTokenFacade: IProcessTokenFacade,
     processModelFacade: IProcessModelFacade,
     identity: IIdentity,
@@ -107,23 +108,21 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
 
     return new Promise<void>(async (resolve: Function, reject: Function): Promise<void> => {
       try {
-        const flowNodeInstance = flowNodeInstances.find((instance: FlowNodeInstance): boolean => instance.flowNodeId === this.flowNode.id);
-
-        this.previousFlowNodeInstanceId = flowNodeInstance.previousFlowNodeInstanceId;
-        this.flowNodeInstanceId = flowNodeInstance.id;
+        this.previousFlowNodeInstanceId = flowNodeInstanceForHandler.previousFlowNodeInstanceId;
+        this.flowNodeInstanceId = flowNodeInstanceForHandler.id;
 
         // With regards to ParallelGateways, we need to be able to handle multiple results here.
 
         // It doesn't really matter which token is used here, since payload-specific operations should
         // only ever be done during the handlers execution.
         // We only require the token here, so that we can pass infos like ProcessInstanceId or CorrelationId to the hook.
-        const tokenForHandlerHooks = flowNodeInstance.tokens[0];
+        const token = flowNodeInstanceForHandler.tokens[0];
 
-        await this.beforeExecute(tokenForHandlerHooks, processTokenFacade, processModelFacade, identity, reject);
+        await this.beforeExecute(token, processTokenFacade, processModelFacade, identity, reject);
 
-        const nextFlowNodes = await this.resumeFromState(flowNodeInstance, processTokenFacade, processModelFacade, identity);
+        const nextFlowNodes = await this.resumeFromState(flowNodeInstanceForHandler, processTokenFacade, processModelFacade, identity);
 
-        await this.afterExecute(tokenForHandlerHooks, processTokenFacade, processModelFacade, identity);
+        await this.afterExecute(token, processTokenFacade, processModelFacade, identity);
 
         const nextFlowNodesFound = nextFlowNodes && nextFlowNodes.length > 0;
         if (nextFlowNodesFound) {
@@ -133,34 +132,33 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
             .pop();
 
           const handleNextFlowNode = async (nextFlowNode: Model.Base.FlowNode): Promise<void> => {
-            const processToken = processTokenFacade.createProcessToken(currentResult.result);
-
-            const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processToken);
-
-            const nextFlowNodeInstance = flowNodeInstances.find((instance: FlowNodeInstance): boolean => instance.flowNodeId === nextFlowNode.id);
-
-            processToken.flowNodeInstanceId = nextFlowNodeInstance
-              ? nextFlowNodeInstance.id
-              : nextFlowNodeHandler.getInstanceId();
-
-            // If we must execute multiple branches, then each branch must get its own ProcessToken and Facade.
-            const tokenForNextFlowNode = nextFlowNodes.length > 1
-              ? processTokenFacade.createProcessToken(processToken.payload)
-              : processToken;
+            const processTokenForBranch = nextFlowNodes.length > 1
+              ? processTokenFacade.createProcessToken(currentResult)
+              : token;
 
             const processTokenFacadeForFlowNode = nextFlowNodes.length > 1
               ? processTokenFacade.getProcessTokenFacadeForParallelBranch()
               : processTokenFacade;
 
+            const nextFlowNodeInstance = allFlowNodeInstances.find((instance: FlowNodeInstance): boolean => {
+              return instance.flowNodeId === nextFlowNode.id &&
+                     instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
+            });
+
+            const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);
+
+            processTokenForBranch.flowNodeInstanceId = nextFlowNodeInstance.id || nextFlowNodeHandler.getInstanceId();
+
             // An instance for the next FlowNode has already been created. Continue resuming
             if (nextFlowNodeInstance) {
-              return nextFlowNodeHandler.resume(flowNodeInstances, processTokenFacadeForFlowNode, processModelFacade, identity);
+              return nextFlowNodeHandler
+                .resume(nextFlowNodeInstance, allFlowNodeInstances, processTokenFacadeForFlowNode, processModelFacade, identity);
             }
 
             // No instance for the next FlowNode was found.
             // We have arrived at the point at which the ProcessInstance was interrupted and can continue normally.
             return nextFlowNodeHandler
-              .execute(tokenForNextFlowNode, processTokenFacadeForFlowNode, processModelFacade, identity, this.flowNodeInstanceId);
+              .execute(processTokenForBranch, processTokenFacadeForFlowNode, processModelFacade, identity, this.flowNodeInstanceId);
           };
 
           const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -147,7 +147,9 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
 
             const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);
 
-            processTokenForBranch.flowNodeInstanceId = nextFlowNodeInstance.id || nextFlowNodeHandler.getInstanceId();
+            processTokenForBranch.flowNodeInstanceId = nextFlowNodeInstance
+              ? nextFlowNodeInstance.id
+              : nextFlowNodeHandler.getInstanceId();
 
             // An instance for the next FlowNode has already been created. Continue resuming
             if (nextFlowNodeInstance) {

--- a/src/runtime/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/flow_node_handler/flow_node_handler.ts
@@ -80,7 +80,8 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
   ): Promise<void>;
 
   public abstract async resume(
-    flowNodeInstances: Array<FlowNodeInstance>,
+    flowNodeInstanceForHandler: FlowNodeInstance,
+    allFlowNodeInstances: Array<FlowNodeInstance>,
     processTokenFacade: IProcessTokenFacade,
     processModelFacade: IProcessModelFacade,
     identity: IIdentity,

--- a/src/runtime/flow_node_handler/gateway_handler/exclusive_gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/exclusive_gateway_handler.ts
@@ -61,9 +61,8 @@ export class ExclusiveGatewayHandler extends GatewayHandler<Model.Gateways.Exclu
 
     // Since the Gateway was finished without error, we can assume that only one outgoing SequenceFlow with a matching condition exists.
     // If this were not the case, the Gateway would not have been executed at all.
-    const matchingSequenceFlows = await this.getSequenceFlowsWithMatchingCondition(outgoingSequenceFlows, processTokenFacade);
-
-    const nextFlowNodeAfterSplit = processModelFacade.getFlowNodeById(matchingSequenceFlows[0].targetRef);
+    const nextFlowNodeId = await this.determineBranchToTake(onExitToken, outgoingSequenceFlows, processTokenFacade);
+    const nextFlowNodeAfterSplit = processModelFacade.getFlowNodeById(nextFlowNodeId);
 
     return [nextFlowNodeAfterSplit];
   }
@@ -107,9 +106,9 @@ export class ExclusiveGatewayHandler extends GatewayHandler<Model.Gateways.Exclu
     // If this is a split gateway, find the SequenceFlow that has a truthy condition
     // and continue execution with its target FlowNode.
     const nextFlowNodeId = await this.determineBranchToTake(token, outgoingSequenceFlows, processTokenFacade);
-    await this.persistOnExit(token);
-
     const nextFlowNodeAfterSplit = processModelFacade.getFlowNodeById(nextFlowNodeId);
+
+    await this.persistOnExit(token);
 
     return [nextFlowNodeAfterSplit];
   }

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -86,7 +86,8 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
   }
 
   public async resume(
-    flowNodeInstances: Array<FlowNodeInstance>,
+    flowNodeInstanceForHandler: FlowNodeInstance,
+    allFlowNodeInstances: Array<FlowNodeInstance>,
     processTokenFacade: IProcessTokenFacade,
     processModelFacade: IProcessModelFacade,
     identity: IIdentity,
@@ -94,24 +95,22 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
 
     return new Promise<void>(async (resolve: Function, reject: Function): Promise<void> => {
       try {
-        const flowNodeInstance = flowNodeInstances.find((instance: FlowNodeInstance): boolean => instance.flowNodeId === this.flowNode.id);
-
-        this.previousFlowNodeInstanceId = flowNodeInstance.previousFlowNodeInstanceId;
-        this.flowNodeInstanceId = flowNodeInstance.id;
+        this.previousFlowNodeInstanceId = flowNodeInstanceForHandler.previousFlowNodeInstanceId;
+        this.flowNodeInstanceId = flowNodeInstanceForHandler.id;
 
         // It doesn't really matter which token is used here, since payload-specific operations should
         // only ever be done during the handlers execution.
         // We only require the token here, so that we can pass infos like ProcessInstanceId or CorrelationId to the hook.
-        const tokenForHandlerHooks = flowNodeInstance.tokens[0];
+        const token = flowNodeInstanceForHandler.tokens[0];
 
-        await this.beforeExecute(tokenForHandlerHooks, processTokenFacade, processModelFacade, identity);
+        await this.beforeExecute(token, processTokenFacade, processModelFacade, identity);
 
-        this.terminationSubscription = this.subscribeToProcessTermination(tokenForHandlerHooks, reject);
+        this.terminationSubscription = this.subscribeToProcessTermination(token, reject);
 
         // With regards to ParallelGateways, we need to be able to handle multiple results here.
-        const nextFlowNodes = await this.resumeFromState(flowNodeInstance, processTokenFacade, processModelFacade, identity);
+        const nextFlowNodes = await this.resumeFromState(flowNodeInstanceForHandler, processTokenFacade, processModelFacade, identity);
 
-        await this.afterExecute(tokenForHandlerHooks, processTokenFacade, processModelFacade, identity);
+        await this.afterExecute(token, processTokenFacade, processModelFacade, identity);
 
         const nextFlowNodesFound = nextFlowNodes && nextFlowNodes.length > 0;
         if (nextFlowNodesFound) {
@@ -121,34 +120,33 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
             .pop();
 
           const handleNextFlowNode = async (nextFlowNode: Model.Base.FlowNode): Promise<void> => {
-            const processToken = processTokenFacade.createProcessToken(currentResult.result);
-
-            const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processToken);
-
-            const nextFlowNodeInstance = flowNodeInstances.find((instance: FlowNodeInstance): boolean => instance.flowNodeId === nextFlowNode.id);
-
-            processToken.flowNodeInstanceId = nextFlowNodeInstance
-              ? nextFlowNodeInstance.id
-              : nextFlowNodeHandler.getInstanceId();
-
-            // If we must execute multiple branches, then each branch must get its own ProcessToken and Facade.
-            const tokenForNextFlowNode = nextFlowNodes.length > 1
-              ? processTokenFacade.createProcessToken(processToken.payload)
-              : processToken;
+            const processTokenForBranch = nextFlowNodes.length > 1
+              ? processTokenFacade.createProcessToken(currentResult)
+              : token;
 
             const processTokenFacadeForFlowNode = nextFlowNodes.length > 1
               ? processTokenFacade.getProcessTokenFacadeForParallelBranch()
               : processTokenFacade;
 
+            const nextFlowNodeInstance = allFlowNodeInstances.find((instance: FlowNodeInstance): boolean => {
+              return instance.flowNodeId === nextFlowNode.id &&
+                     instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
+            });
+
+            const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);
+
+            processTokenForBranch.flowNodeInstanceId = nextFlowNodeInstance.id || nextFlowNodeHandler.getInstanceId();
+
             // An instance for the next FlowNode has already been created. Continue resuming
             if (nextFlowNodeInstance) {
-              return nextFlowNodeHandler.resume(flowNodeInstances, processTokenFacadeForFlowNode, processModelFacade, identity);
+              return nextFlowNodeHandler
+                .resume(nextFlowNodeInstance, allFlowNodeInstances, processTokenFacadeForFlowNode, processModelFacade, identity);
             }
 
             // No instance for the next FlowNode was found.
             // We have arrived at the point at which the ProcessInstance was interrupted and can continue normally.
             return nextFlowNodeHandler
-              .execute(tokenForNextFlowNode, processTokenFacadeForFlowNode, processModelFacade, identity, this.flowNodeInstanceId);
+              .execute(processTokenForBranch, processTokenFacadeForFlowNode, processModelFacade, identity, this.flowNodeInstanceId);
           };
 
           const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -135,7 +135,9 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
 
             const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);
 
-            processTokenForBranch.flowNodeInstanceId = nextFlowNodeInstance.id || nextFlowNodeHandler.getInstanceId();
+            processTokenForBranch.flowNodeInstanceId = nextFlowNodeInstance
+              ? nextFlowNodeInstance.id
+              : nextFlowNodeHandler.getInstanceId();
 
             // An instance for the next FlowNode has already been created. Continue resuming
             if (nextFlowNodeInstance) {

--- a/src/runtime/resume_process_serivce.ts
+++ b/src/runtime/resume_process_serivce.ts
@@ -209,9 +209,14 @@ export class ResumeProcessService implements IResumeProcessService {
 
       const flowNodeHandler = await this.flowNodeHandlerFactory.create(processInstanceConfig.startEvent);
 
+      const flowNodeInstance = flowNodeInstances.find((entry: FlowNodeInstance): boolean => {
+        return entry.flowNodeId === processInstanceConfig.startEvent.id;
+      });
+
       logger.info(`Resuming ProcessInstance with instance ID ${processInstanceId} and model ID ${processModelId}...`);
 
       await flowNodeHandler.resume(
+        flowNodeInstance,
         flowNodeInstances,
         processInstanceConfig.processTokenFacade,
         processInstanceConfig.processModelFacade,


### PR DESCRIPTION
## Changes

1. Fix FlowNodeInstance resumption:
    - The function will no longer determine the FlowNodeInstance to resume by itself. This has proven ineffective, when dealing with a FlowNode that was executed multiple times within a single ProcessInstance.
    -  Each FlowNodeHandler's resume function will now expect the matching FlowNodeInstance to be passed as a parameter.
    - After the handler has finished, it will determine the next FlowNodes, as well as all matching FlowNodeInstances to resume. 
2. Fix ExclusiveGateway path resolving during resumption
    - Resuming the gateway did not account for default SequenceFlows. This is fixed now.
3. Remove some duplicated ProcessToken creations that occurred during FlowNodeHandler resumption.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/332

PR: #275

## How to test the changes

Use this version of the Runtime with BPMN Studio:
https://github.com/process-engine/process_engine_runtime/tree/feature/fix_resumption_for_flow_nodes_with_multiple_instances

Follow the steps described here:
https://github.com/process-engine/process_engine_runtime/issues/332

See that the ProcessModel will now be executed and resumed correctly.
