### PR TITLE
🐛 Store all previousFlowNodeInstanceIds for ParallelJoinGateways

### DIFF
--- a/src/runtime/facades/process_token_facade.ts
+++ b/src/runtime/facades/process_token_facade.ts
@@ -1,4 +1,6 @@
 import {ProcessToken} from '@process-engine/flow_node_instance.contracts';
+import * as clone from 'clone';
+
 import {IFlowNodeInstanceResult, IProcessTokenFacade} from '@process-engine/process_engine_contracts';
 
 export class ProcessTokenFacade implements IProcessTokenFacade {
@@ -17,7 +19,9 @@ export class ProcessTokenFacade implements IProcessTokenFacade {
   }
 
   public getAllResults(): Array<IFlowNodeInstanceResult> {
-    return this.processTokenResults;
+    // Must return a copy here, or whoever gets the result will be
+    // able to manipulate the actual values stored by this facade!
+    return clone(this.processTokenResults);
   }
 
   public createProcessToken(payload?: any): ProcessToken {

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -197,7 +197,10 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
               // These IDs are separated by ";", i.e.: ID1;ID2;ID3, etc.
               // We need to account for that fact here.
               // indexOf will return 0, if the two IDs are exact matches.
-              const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
+              const instanceFollowedCurrentFlowNode =
+                instance.previousFlowNodeInstanceId &&
+                instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
+
               const flowNodeIdsMatch = instance.flowNodeId === nextFlowNode.id;
 
               return instanceFollowedCurrentFlowNode && flowNodeIdsMatch;

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -174,11 +174,11 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
             // NOTE:
             // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
-            // When multiple branches arrive at the JoinGateway at EXACT same moment, it is possible, that multiple instances for that same Gateway
-            // are registered at the Ioc container.
+            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible,
+            // that multiple instances for that same Gateway are created.
             // Since the Gateway always waits for ALL incoming branches before moving on,
             // this will result in the process instance getting stuck forever.
-            // This helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
+            // Using a timeout helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
             if (nextFlowNodes.length > 1) {
               await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 100));
             }

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -196,18 +196,11 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
               // ParallelJoinGateways always have multiple "previousFlowNodeInstanceIds".
               // These IDs are separated by ";", i.e.: ID1;ID2;ID3, etc.
               // We need to account for that fact here.
-              const previousFlowNodeInstanceIdIsAList =
-                instance.previousFlowNodeInstanceId &&
-                instance.previousFlowNodeInstanceId.indexOf(';') > -1;
+              // indexOf will return 0, if the two IDs are exact matches.
+              const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
+              const flowNodeIdsMatch = instance.flowNodeId === nextFlowNode.id;
 
-              if (previousFlowNodeInstanceIdIsAList) {
-                const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
-
-                return instanceFollowedCurrentFlowNode && instance.flowNodeId === nextFlowNode.id;
-              }
-
-              return instance.flowNodeId === nextFlowNode.id &&
-                     instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
+              return instanceFollowedCurrentFlowNode && flowNodeIdsMatch;
             });
 
             const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -201,12 +201,9 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
                 instance.previousFlowNodeInstanceId.indexOf(';') > -1;
 
               if (previousFlowNodeInstanceIdIsAList) {
-                const deserializedPreviousFlowNodeInstanceIds = instance.previousFlowNodeInstanceId.split(';');
-                const instanceHasMatchingPreviousFlowNodeInstanceId = deserializedPreviousFlowNodeInstanceIds.some((entry): boolean => {
-                  return entry === this.flowNodeInstanceId;
-                });
+                const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
 
-                return instanceHasMatchingPreviousFlowNodeInstanceId && instance.flowNodeId === nextFlowNode.id;
+                return instanceFollowedCurrentFlowNode && instance.flowNodeId === nextFlowNode.id;
               }
 
               return instance.flowNodeId === nextFlowNode.id &&

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -111,7 +111,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
       let nextFlowNodes: Array<Model.Base.FlowNode>;
 
       // It doesn't really matter which token is used here, since payload-specific operations should
-      // only ever be done during the handlers execution.
+      // only ever be done during the handler's execution.
       // We only require the token here, so that we can pass infos like ProcessInstanceId or CorrelationId to the hook.
       const token = flowNodeInstanceForHandler.tokens[0];
 
@@ -173,8 +173,8 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
 
             // NOTE:
-            // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
-            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible,
+            // This is a workaround for a problem with the resumption of multiple parallel branches that were executed right up to the JoinGateway.
+            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible
             // that multiple instances for that same Gateway are created.
             // Since the Gateway always waits for ALL incoming branches before moving on,
             // this will result in the process instance getting stuck forever.

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -47,10 +47,10 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
   ): Promise<void> {
 
     return new Promise<void>(async (resolve: Function, reject: Function): Promise<void> => {
-      try {
-        this.previousFlowNodeInstanceId = previousFlowNodeInstanceId;
-        token.flowNodeInstanceId = this.flowNodeInstanceId;
+      this.previousFlowNodeInstanceId = previousFlowNodeInstanceId;
+      token.flowNodeInstanceId = this.flowNodeInstanceId;
 
+      try {
         this.terminationSubscription = this.subscribeToProcessTermination(token, reject);
         await this.attachBoundaryEvents(token, processTokenFacade, processModelFacade, identity, resolve);
 
@@ -63,12 +63,12 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
         const processIsNotYetFinished = nextFlowNodes !== undefined && nextFlowNodes.length > 0;
         if (processIsNotYetFinished) {
 
-          const executeNextFlowNode = async (nextFlowNode: Model.Base.FlowNode): Promise<void> => {
-            const nextFlowNodeHandler =
-              await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, token);
+          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
+
+          for (const nextFlowNode of nextFlowNodes) {
 
             // If we must execute multiple branches, then each branch must get its own ProcessToken and Facade.
-            const tokenForNextFlowNode = nextFlowNodes.length > 1
+            const processTokenForBranch = nextFlowNodes.length > 1
               ? processTokenFacade.createProcessToken(token.payload)
               : token;
 
@@ -76,17 +76,14 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
               ? processTokenFacade.getProcessTokenFacadeForParallelBranch()
               : processTokenFacade;
 
-            tokenForNextFlowNode.flowNodeInstanceId = nextFlowNodeHandler.getInstanceId();
-
-            return nextFlowNodeHandler
-              .execute(tokenForNextFlowNode, processTokenFacadeForFlowNode, processModelFacade, identity, this.flowNodeInstanceId);
-          };
-
-          // We cannot use `Promise.map` or `Promise.each` here, because the branches would not run truly in parallel to each other.
-          // The only way to guarantee that is to create the promises and then use `Promise.all` to await all of them.
-          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
-          for (const nextFlowNode of nextFlowNodes) {
-            nextFlowNodeExecutionPromises.push(executeNextFlowNode(nextFlowNode));
+            const handleNextFlowNodePromise = this.handleNextFlowNode(
+              nextFlowNode,
+              processTokenFacadeForFlowNode,
+              processModelFacade,
+              processTokenForBranch,
+              identity,
+            );
+            nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);
@@ -94,35 +91,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
         return resolve();
       } catch (error) {
-        const allResults = processTokenFacade.getAllResults();
-        // This check is necessary to prevent duplicate entries,
-        // in case the Promise-Chain was broken further down the road.
-        const noResultStoredYet = !allResults.some((entry: IFlowNodeInstanceResult): boolean => entry.flowNodeInstanceId === this.flowNodeInstanceId);
-        if (noResultStoredYet) {
-          processTokenFacade.addResultForFlowNode(this.flowNode.id, this.flowNodeInstanceId, error);
-        }
-
-        const errorBoundaryEvents = this.findErrorBoundaryEventHandlersForError(error);
-
-        await this.afterExecute(token);
-
-        const terminationRegex = /terminated/i;
-        const isTerminationMessage = terminationRegex.test(error.message);
-
-        const noErrorBoundaryEventsAvailable = !errorBoundaryEvents || errorBoundaryEvents.length === 0;
-        if (noErrorBoundaryEventsAvailable || isTerminationMessage) {
-          return reject(error);
-        }
-
-        token.payload = error;
-
-        await Promise.map(errorBoundaryEvents, async (errorHandler: ErrorBoundaryEventHandler): Promise<void> => {
-          const flowNodeAfterBoundaryEvent = errorHandler.getNextFlowNode(processModelFacade);
-          const errorHandlerId = errorHandler.getInstanceId();
-          await this.continueAfterBoundaryEvent(errorHandlerId, flowNodeAfterBoundaryEvent, token, processTokenFacade, processModelFacade, identity);
-        });
-
-        return resolve();
+        return this.handleActivityError(token, error, processTokenFacade, processModelFacade, identity, resolve, reject);
       }
     });
   }
@@ -136,18 +105,17 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
   ): Promise<void> {
 
     return new Promise<void>(async (resolve: Function, reject: Function): Promise<void> => {
+      this.previousFlowNodeInstanceId = flowNodeInstanceForHandler.previousFlowNodeInstanceId;
+      this.flowNodeInstanceId = flowNodeInstanceForHandler.id;
+
+      let nextFlowNodes: Array<Model.Base.FlowNode>;
+
+      // It doesn't really matter which token is used here, since payload-specific operations should
+      // only ever be done during the handlers execution.
+      // We only require the token here, so that we can pass infos like ProcessInstanceId or CorrelationId to the hook.
+      const token = flowNodeInstanceForHandler.tokens[0];
+
       try {
-        this.previousFlowNodeInstanceId = flowNodeInstanceForHandler.previousFlowNodeInstanceId;
-        this.flowNodeInstanceId = flowNodeInstanceForHandler.id;
-
-        // WIth regards to ParallelGateways, we need to be able to handle multiple results here.
-        let nextFlowNodes: Array<Model.Base.FlowNode>;
-
-        // It doesn't really matter which token is used here, since payload-specific operations should
-        // only ever be done during the handlers execution.
-        // We only require the token here, so that we can pass infos like ProcessInstanceId or CorrelationId to the hook.
-        const token = flowNodeInstanceForHandler.tokens[0];
-
         const flowNodeInstancesAfterBoundaryEvents = this.getFlowNodeInstancesAfterBoundaryEvents(allFlowNodeInstances, processModelFacade);
 
         await this.beforeExecute(token, processTokenFacade, processModelFacade, identity);
@@ -175,14 +143,14 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
         const processIsNotYetFinished = nextFlowNodes && nextFlowNodes.length > 0;
         if (processIsNotYetFinished) {
 
-          // No instance for the next FlowNode was found.
-          // We have arrived at the point at which the ProcessInstance was interrupted and can continue normally.
           const currentResult = processTokenFacade
             .getAllResults()
             .pop();
 
-          const handleNextFlowNode = async (nextFlowNode: Model.Base.FlowNode): Promise<void> => {
-            // If we must execute multiple branches, then each branch must get its own ProcessToken and Facade.
+          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
+
+          for (const nextFlowNode of nextFlowNodes) {
+
             const processTokenForBranch = nextFlowNodes.length > 1
               ? processTokenFacade.createProcessToken(currentResult)
               : token;
@@ -191,42 +159,18 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
               ? processTokenFacade.getProcessTokenFacadeForParallelBranch()
               : processTokenFacade;
 
-            const nextFlowNodeInstance = allFlowNodeInstances.find((instance: FlowNodeInstance): boolean => {
+            const nextFlowNodeInstance = this.findNextInstanceOfFlowNode(allFlowNodeInstances, nextFlowNode.id);
 
-              // ParallelJoinGateways always have multiple "previousFlowNodeInstanceIds".
-              // These IDs are separated by ";", i.e.: ID1;ID2;ID3, etc.
-              // We need to account for that fact here.
-              // indexOf will return 0, if the two IDs are exact matches.
-              const instanceFollowedCurrentFlowNode =
-                instance.previousFlowNodeInstanceId &&
-                instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
-
-              const flowNodeIdsMatch = instance.flowNodeId === nextFlowNode.id;
-
-              return instanceFollowedCurrentFlowNode && flowNodeIdsMatch;
-            });
-
-            const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);
-
-            processTokenForBranch.flowNodeInstanceId = nextFlowNodeInstance
-              ? nextFlowNodeInstance.id
-              : nextFlowNodeHandler.getInstanceId();
-
-            // An instance for the next FlowNode has already been created. Continue resuming
-            if (nextFlowNodeInstance) {
-              return nextFlowNodeHandler
-                .resume(nextFlowNodeInstance, allFlowNodeInstances, processTokenFacadeForFlowNode, processModelFacade, identity);
-            }
-
-            return nextFlowNodeHandler
-              .execute(processTokenForBranch, processTokenFacadeForFlowNode, processModelFacade, identity, this.flowNodeInstanceId);
-          };
-
-          // We cannot use `Promise.map` or `Promise.each` here, because the branches would not run truly in parallel to each other.
-          // The only way to guarantee that is to create the promises and then use `Promise.all` to await all of them.
-          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
-          for (const nextFlowNode of nextFlowNodes) {
-            nextFlowNodeExecutionPromises.push(handleNextFlowNode(nextFlowNode));
+            const handleNextFlowNodePromise = this.handleNextFlowNode(
+              nextFlowNode,
+              processTokenFacadeForFlowNode,
+              processModelFacade,
+              processTokenForBranch,
+              identity,
+              nextFlowNodeInstance,
+              allFlowNodeInstances,
+            );
+            nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);
@@ -234,38 +178,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
         return resolve();
       } catch (error) {
-        const allResults = processTokenFacade.getAllResults();
-        // This check is necessary to prevent duplicate entries,
-        // in case the Promise-Chain was broken further down the road.
-        const noResultStoredYet = !allResults.some((entry: IFlowNodeInstanceResult): boolean => entry.flowNodeInstanceId === this.flowNodeInstanceId);
-        if (noResultStoredYet) {
-          processTokenFacade.addResultForFlowNode(this.flowNode.id, this.flowNodeInstanceId, error);
-        }
-
-        const token = processTokenFacade.createProcessToken();
-        token.payload = error;
-        token.flowNodeInstanceId = this.flowNodeInstanceId;
-
-        const errorBoundaryEvents = this.findErrorBoundaryEventHandlersForError(error);
-
-        await this.afterExecute(token);
-
-        const terminationRegex = /terminated/i;
-        const isTerminationMessage = terminationRegex.test(error.message);
-
-        const noErrorBoundaryEventsAvailable = !errorBoundaryEvents || errorBoundaryEvents.length === 0;
-
-        if (noErrorBoundaryEventsAvailable || isTerminationMessage) {
-          return reject(error);
-        }
-
-        await Promise.map(errorBoundaryEvents, async (errorHandler: ErrorBoundaryEventHandler): Promise<void> => {
-          const flowNodeAfterBoundaryEvent = errorHandler.getNextFlowNode(processModelFacade);
-          const errorHandlerId = errorHandler.getInstanceId();
-          await this.continueAfterBoundaryEvent(errorHandlerId, flowNodeAfterBoundaryEvent, token, processTokenFacade, processModelFacade, identity);
-        });
-
-        return resolve();
+        return this.handleActivityError(token, error, processTokenFacade, processModelFacade, identity, resolve, reject);
       }
     });
   }
@@ -408,6 +321,47 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
     };
 
     return this.eventAggregator.subscribeOnce(terminateEvent, onTerminatedCallback);
+  }
+
+  private async handleActivityError(
+    token: ProcessToken,
+    error: Error,
+    processTokenFacade: IProcessTokenFacade,
+    processModelFacade: IProcessModelFacade,
+    identity: IIdentity,
+    resolveFunc: Function,
+    rejectFunc: Function,
+  ): Promise<void> {
+
+    token.payload = error;
+
+    const allResults = processTokenFacade.getAllResults();
+    // This check is necessary to prevent duplicate entries,
+    // in case the Promise-Chain was broken further down the road.
+    const noResultStoredYet = !allResults.some((entry: IFlowNodeInstanceResult): boolean => entry.flowNodeInstanceId === this.flowNodeInstanceId);
+    if (noResultStoredYet) {
+      processTokenFacade.addResultForFlowNode(this.flowNode.id, this.flowNodeInstanceId, error);
+    }
+
+    const errorBoundaryEvents = this.findErrorBoundaryEventHandlersForError(error);
+
+    await this.afterExecute(token);
+
+    const terminationRegex = /terminated/i;
+    const isTerminationMessage = terminationRegex.test(error.message);
+
+    const noErrorBoundaryEventsAvailable = !errorBoundaryEvents || errorBoundaryEvents.length === 0;
+    if (noErrorBoundaryEventsAvailable || isTerminationMessage) {
+      return rejectFunc(error);
+    }
+
+    await Promise.map(errorBoundaryEvents, async (errorHandler: ErrorBoundaryEventHandler): Promise<void> => {
+      const flowNodeAfterBoundaryEvent = errorHandler.getNextFlowNode(processModelFacade);
+      const errorHandlerId = errorHandler.getInstanceId();
+      await this.continueAfterBoundaryEvent(errorHandlerId, flowNodeAfterBoundaryEvent, token, processTokenFacade, processModelFacade, identity);
+    });
+
+    return resolveFunc();
   }
 
   private async resumeWithBoundaryEvents(

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -171,6 +171,16 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
               allFlowNodeInstances,
             );
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
+
+            // NOTE:
+            // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
+            // When multiple branches arrive at the JoinGateway at EXACT same moment, it is possible, that multiple instances for that same Gateway
+            // are registered at the Ioc container.
+            // Since the Gateway always waits for ALL incoming branches before moving on, this will result in the process instance getting stuck forever.
+            // This helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
+            if (nextFlowNodes.length > 1) {
+              await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 100));
+            }
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -202,10 +202,15 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
               if (previousFlowNodeInstanceIdIsAList) {
                 const deserializedPreviousFlowNodeInstanceIds = instance.previousFlowNodeInstanceId.split(';');
-                return deserializedPreviousFlowNodeInstanceIds.some((entry): boolean => entry === this.flowNodeInstanceId);
+                const instanceHasMatchingPreviousFlowNodeInstanceId = deserializedPreviousFlowNodeInstanceIds.some((entry): boolean => {
+                  return entry === this.flowNodeInstanceId;
+                });
+
+                return instanceHasMatchingPreviousFlowNodeInstanceId && instance.flowNodeId === nextFlowNode.id;
               }
 
-              return instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
+              return instance.flowNodeId === nextFlowNode.id &&
+                     instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
             });
 
             const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -176,7 +176,8 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
             // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
             // When multiple branches arrive at the JoinGateway at EXACT same moment, it is possible, that multiple instances for that same Gateway
             // are registered at the Ioc container.
-            // Since the Gateway always waits for ALL incoming branches before moving on, this will result in the process instance getting stuck forever.
+            // Since the Gateway always waits for ALL incoming branches before moving on,
+            // this will result in the process instance getting stuck forever.
             // This helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
             if (nextFlowNodes.length > 1) {
               await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 100));

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -140,11 +140,11 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
 
             // NOTE:
             // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
-            // When multiple branches arrive at the JoinGateway at EXACT same moment, it is possible, that multiple instances for that same Gateway
-            // are registered at the Ioc container.
+            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible,
+            // that multiple instances for that same Gateway are created.
             // Since the Gateway always waits for ALL incoming branches before moving on,
             // this will result in the process instance getting stuck forever.
-            // This helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
+            // Using a timeout helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
             if (nextFlowNodes.length > 1) {
               await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 100));
             }

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -143,17 +143,23 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
             const nextFlowNodeInstance = allFlowNodeInstances.find((instance: FlowNodeInstance): boolean => {
 
               // ParallelJoinGateways always have multiple "previousFlowNodeInstanceIds".
+              // These IDs are separated by ";", i.e.: ID1;ID2;ID3, etc.
               // We need to account for that fact here.
-              const previousFlowNodeInstanceIdIsACollection =
+              const previousFlowNodeInstanceIdIsAList =
                 instance.previousFlowNodeInstanceId &&
                 instance.previousFlowNodeInstanceId.indexOf(';') > -1;
 
-              if (previousFlowNodeInstanceIdIsACollection) {
+              if (previousFlowNodeInstanceIdIsAList) {
                 const deserializedPreviousFlowNodeInstanceIds = instance.previousFlowNodeInstanceId.split(';');
-                return deserializedPreviousFlowNodeInstanceIds.some((entry): boolean => entry === this.flowNodeInstanceId);
+                const instanceHasMatchingPreviousFlowNodeInstanceId = deserializedPreviousFlowNodeInstanceIds.some((entry): boolean => {
+                  return entry === this.flowNodeInstanceId;
+                });
+
+                return instanceHasMatchingPreviousFlowNodeInstanceId && instance.flowNodeId === nextFlowNode.id;
               }
 
-              return instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
+              return instance.flowNodeId === nextFlowNode.id &&
+                     instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
             });
 
             const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -141,8 +141,19 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
               : processTokenFacade;
 
             const nextFlowNodeInstance = allFlowNodeInstances.find((instance: FlowNodeInstance): boolean => {
-              return instance.flowNodeId === nextFlowNode.id &&
-                     instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
+
+              // ParallelJoinGateways always have multiple "previousFlowNodeInstanceIds".
+              // We need to account for that fact here.
+              const previousFlowNodeInstanceIdIsACollection =
+                instance.previousFlowNodeInstanceId &&
+                instance.previousFlowNodeInstanceId.indexOf(';') > -1;
+
+              if (previousFlowNodeInstanceIdIsACollection) {
+                const deserializedPreviousFlowNodeInstanceIds = instance.previousFlowNodeInstanceId.split(';');
+                return deserializedPreviousFlowNodeInstanceIds.some((entry): boolean => entry === this.flowNodeInstanceId);
+              }
+
+              return instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
             });
 
             const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -146,7 +146,10 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
               // These IDs are separated by ";", i.e.: ID1;ID2;ID3, etc.
               // We need to account for that fact here.
               // indexOf will return 0, if the two IDs are exact matches.
-              const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
+              const instanceFollowedCurrentFlowNode =
+                instance.previousFlowNodeInstanceId &&
+                instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
+
               const flowNodeIdsMatch = instance.flowNodeId === nextFlowNode.id;
 
               return instanceFollowedCurrentFlowNode && flowNodeIdsMatch;

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -97,7 +97,7 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
       this.flowNodeInstanceId = flowNodeInstanceForHandler.id;
 
       // It doesn't really matter which token is used here, since payload-specific operations should
-      // only ever be done during the handlers execution.
+      // only ever be done during the handler's execution.
       // We only require the token here, so that we can pass infos like ProcessInstanceId or CorrelationId to the hook.
       const token = flowNodeInstanceForHandler.tokens[0];
 
@@ -139,8 +139,8 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
 
             // NOTE:
-            // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
-            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible,
+            // This is a workaround for a problem with the resumption of multiple parallel branches that were executed right up to the JoinGateway.
+            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible
             // that multiple instances for that same Gateway are created.
             // Since the Gateway always waits for ALL incoming branches before moving on,
             // this will result in the process instance getting stuck forever.

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -150,12 +150,9 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
                 instance.previousFlowNodeInstanceId.indexOf(';') > -1;
 
               if (previousFlowNodeInstanceIdIsAList) {
-                const deserializedPreviousFlowNodeInstanceIds = instance.previousFlowNodeInstanceId.split(';');
-                const instanceHasMatchingPreviousFlowNodeInstanceId = deserializedPreviousFlowNodeInstanceIds.some((entry): boolean => {
-                  return entry === this.flowNodeInstanceId;
-                });
+                const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
 
-                return instanceHasMatchingPreviousFlowNodeInstanceId && instance.flowNodeId === nextFlowNode.id;
+                return instanceFollowedCurrentFlowNode && instance.flowNodeId === nextFlowNode.id;
               }
 
               return instance.flowNodeId === nextFlowNode.id &&

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -137,6 +137,16 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
               allFlowNodeInstances,
             );
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
+
+            // NOTE:
+            // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
+            // When multiple branches arrive at the JoinGateway at EXACT same moment, it is possible, that multiple instances for that same Gateway
+            // are registered at the Ioc container.
+            // Since the Gateway always waits for ALL incoming branches before moving on, this will result in the process instance getting stuck forever.
+            // This helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
+            if (nextFlowNodes.length > 1) {
+              await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 100));
+            }
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -8,7 +8,6 @@ import {
   ProcessTokenType,
 } from '@process-engine/flow_node_instance.contracts';
 import {
-  IFlowNodeInstanceResult,
   IProcessModelFacade,
   IProcessTokenFacade,
 } from '@process-engine/process_engine_contracts';
@@ -41,22 +40,23 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
   ): Promise<void> {
 
     return new Promise<void>(async (resolve: Function, reject: Function): Promise<void> => {
-      try {
-        this.previousFlowNodeInstanceId = previousFlowNodeInstanceId;
-        token.flowNodeInstanceId = this.flowNodeInstanceId;
+      this.previousFlowNodeInstanceId = previousFlowNodeInstanceId;
+      token.flowNodeInstanceId = this.flowNodeInstanceId;
 
+      try {
         await this.beforeExecute(token, processTokenFacade, processModelFacade, identity, reject);
         const nextFlowNodes = await this.startExecution(token, processTokenFacade, processModelFacade, identity);
         await this.afterExecute(token, processTokenFacade, processModelFacade, identity);
 
-        const nextFlowNodesFound = nextFlowNodes && nextFlowNodes.length > 0;
-        if (nextFlowNodesFound) {
+        const processIsNotYetFinished = nextFlowNodes && nextFlowNodes.length > 0;
+        if (processIsNotYetFinished) {
 
-          const executeNextFlowNode = async (nextFlowNode: Model.Base.FlowNode): Promise<void> => {
-            const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, token);
+          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
+
+          for (const nextFlowNode of nextFlowNodes) {
 
             // If we must execute multiple branches, then each branch must get its own ProcessToken and Facade.
-            const tokenForNextFlowNode = nextFlowNodes.length > 1
+            const processTokenForBranch = nextFlowNodes.length > 1
               ? processTokenFacade.createProcessToken(token.payload)
               : token;
 
@@ -64,15 +64,14 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
               ? processTokenFacade.getProcessTokenFacadeForParallelBranch()
               : processTokenFacade;
 
-            tokenForNextFlowNode.flowNodeInstanceId = nextFlowNodeHandler.getInstanceId();
-
-            return nextFlowNodeHandler
-              .execute(tokenForNextFlowNode, processTokenFacadeForFlowNode, processModelFacade, identity, this.flowNodeInstanceId);
-          };
-
-          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
-          for (const nextFlowNode of nextFlowNodes) {
-            nextFlowNodeExecutionPromises.push(executeNextFlowNode(nextFlowNode));
+            const handleNextFlowNodePromise = this.handleNextFlowNode(
+              nextFlowNode,
+              processTokenFacadeForFlowNode,
+              processModelFacade,
+              processTokenForBranch,
+              identity,
+            );
+            nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);
@@ -80,20 +79,7 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
 
         return resolve();
       } catch (error) {
-
-        token.payload = error;
-
-        const allResults = processTokenFacade.getAllResults();
-        // This check is necessary to prevent duplicate entries, in case the Promise-Chain was broken further down the road.
-        const noResultStoredYet = !allResults.some((entry: IFlowNodeInstanceResult): boolean => entry.flowNodeInstanceId === this.flowNodeInstanceId);
-
-        if (noResultStoredYet) {
-          processTokenFacade.addResultForFlowNode(this.flowNode.id, this.flowNodeInstanceId, error);
-        }
-
-        await this.afterExecute(token);
-
-        return reject(error);
+        return this.handleError(token, error, processTokenFacade, reject);
       }
     });
   }
@@ -107,31 +93,30 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
   ): Promise<void> {
 
     return new Promise<void>(async (resolve: Function, reject: Function): Promise<void> => {
+      this.previousFlowNodeInstanceId = flowNodeInstanceForHandler.previousFlowNodeInstanceId;
+      this.flowNodeInstanceId = flowNodeInstanceForHandler.id;
+
+      // It doesn't really matter which token is used here, since payload-specific operations should
+      // only ever be done during the handlers execution.
+      // We only require the token here, so that we can pass infos like ProcessInstanceId or CorrelationId to the hook.
+      const token = flowNodeInstanceForHandler.tokens[0];
+
       try {
-        this.previousFlowNodeInstanceId = flowNodeInstanceForHandler.previousFlowNodeInstanceId;
-        this.flowNodeInstanceId = flowNodeInstanceForHandler.id;
-
-        // With regards to ParallelGateways, we need to be able to handle multiple results here.
-
-        // It doesn't really matter which token is used here, since payload-specific operations should
-        // only ever be done during the handlers execution.
-        // We only require the token here, so that we can pass infos like ProcessInstanceId or CorrelationId to the hook.
-        const token = flowNodeInstanceForHandler.tokens[0];
-
         await this.beforeExecute(token, processTokenFacade, processModelFacade, identity, reject);
-
         const nextFlowNodes = await this.resumeFromState(flowNodeInstanceForHandler, processTokenFacade, processModelFacade, identity);
-
         await this.afterExecute(token, processTokenFacade, processModelFacade, identity);
 
-        const nextFlowNodesFound = nextFlowNodes && nextFlowNodes.length > 0;
-        if (nextFlowNodesFound) {
+        const processIsNotYetFinished = nextFlowNodes && nextFlowNodes.length > 0;
+        if (processIsNotYetFinished) {
 
           const currentResult = processTokenFacade
             .getAllResults()
             .pop();
 
-          const handleNextFlowNode = async (nextFlowNode: Model.Base.FlowNode): Promise<void> => {
+          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
+
+          for (const nextFlowNode of nextFlowNodes) {
+
             const processTokenForBranch = nextFlowNodes.length > 1
               ? processTokenFacade.createProcessToken(currentResult)
               : token;
@@ -140,42 +125,18 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
               ? processTokenFacade.getProcessTokenFacadeForParallelBranch()
               : processTokenFacade;
 
-            const nextFlowNodeInstance = allFlowNodeInstances.find((instance: FlowNodeInstance): boolean => {
+            const nextFlowNodeInstance = this.findNextInstanceOfFlowNode(allFlowNodeInstances, nextFlowNode.id);
 
-              // ParallelJoinGateways always have multiple "previousFlowNodeInstanceIds".
-              // These IDs are separated by ";", i.e.: ID1;ID2;ID3, etc.
-              // We need to account for that fact here.
-              // indexOf will return 0, if the two IDs are exact matches.
-              const instanceFollowedCurrentFlowNode =
-                instance.previousFlowNodeInstanceId &&
-                instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
-
-              const flowNodeIdsMatch = instance.flowNodeId === nextFlowNode.id;
-
-              return instanceFollowedCurrentFlowNode && flowNodeIdsMatch;
-            });
-
-            const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);
-
-            processTokenForBranch.flowNodeInstanceId = nextFlowNodeInstance
-              ? nextFlowNodeInstance.id
-              : nextFlowNodeHandler.getInstanceId();
-
-            // An instance for the next FlowNode has already been created. Continue resuming
-            if (nextFlowNodeInstance) {
-              return nextFlowNodeHandler
-                .resume(nextFlowNodeInstance, allFlowNodeInstances, processTokenFacadeForFlowNode, processModelFacade, identity);
-            }
-
-            // No instance for the next FlowNode was found.
-            // We have arrived at the point at which the ProcessInstance was interrupted and can continue normally.
-            return nextFlowNodeHandler
-              .execute(processTokenForBranch, processTokenFacadeForFlowNode, processModelFacade, identity, this.flowNodeInstanceId);
-          };
-
-          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
-          for (const nextFlowNode of nextFlowNodes) {
-            nextFlowNodeExecutionPromises.push(handleNextFlowNode(nextFlowNode));
+            const handleNextFlowNodePromise = this.handleNextFlowNode(
+              nextFlowNode,
+              processTokenFacadeForFlowNode,
+              processModelFacade,
+              processTokenForBranch,
+              identity,
+              nextFlowNodeInstance,
+              allFlowNodeInstances,
+            );
+            nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);
@@ -183,23 +144,7 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
 
         return resolve();
       } catch (error) {
-
-        const token = processTokenFacade.createProcessToken();
-        token.payload = error;
-        token.flowNodeInstanceId = this.flowNodeInstanceId;
-
-        // This check is necessary to prevent duplicate entries,
-        // in case the Promise-Chain was broken further down the road.
-        const allResults = processTokenFacade.getAllResults();
-
-        const noResultStoredYet = !allResults.some((entry: IFlowNodeInstanceResult): boolean => entry.flowNodeInstanceId === this.flowNodeInstanceId);
-        if (noResultStoredYet) {
-          processTokenFacade.addResultForFlowNode(this.flowNode.id, this.flowNodeInstanceId, token);
-        }
-
-        await this.afterExecute(token);
-
-        return reject(error);
+        return this.handleError(token, error, processTokenFacade, reject);
       }
     });
   }

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -142,7 +142,8 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
             // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
             // When multiple branches arrive at the JoinGateway at EXACT same moment, it is possible, that multiple instances for that same Gateway
             // are registered at the Ioc container.
-            // Since the Gateway always waits for ALL incoming branches before moving on, this will result in the process instance getting stuck forever.
+            // Since the Gateway always waits for ALL incoming branches before moving on,
+            // this will result in the process instance getting stuck forever.
             // This helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
             if (nextFlowNodes.length > 1) {
               await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 100));

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -145,18 +145,11 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
               // ParallelJoinGateways always have multiple "previousFlowNodeInstanceIds".
               // These IDs are separated by ";", i.e.: ID1;ID2;ID3, etc.
               // We need to account for that fact here.
-              const previousFlowNodeInstanceIdIsAList =
-                instance.previousFlowNodeInstanceId &&
-                instance.previousFlowNodeInstanceId.indexOf(';') > -1;
+              // indexOf will return 0, if the two IDs are exact matches.
+              const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
+              const flowNodeIdsMatch = instance.flowNodeId === nextFlowNode.id;
 
-              if (previousFlowNodeInstanceIdIsAList) {
-                const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
-
-                return instanceFollowedCurrentFlowNode && instance.flowNodeId === nextFlowNode.id;
-              }
-
-              return instance.flowNodeId === nextFlowNode.id &&
-                     instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
+              return instanceFollowedCurrentFlowNode && flowNodeIdsMatch;
             });
 
             const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);

--- a/src/runtime/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/flow_node_handler/flow_node_handler.ts
@@ -190,8 +190,13 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
     return processModelFacade.getNextFlowNodesFor(this.flowNode);
   }
 
-  protected async persistOnEnter(processToken: ProcessToken): Promise<void> {
-    await this.flowNodePersistenceFacade.persistOnEnter(this.flowNode, this.flowNodeInstanceId, processToken, this.previousFlowNodeInstanceId);
+  protected async persistOnEnter(processToken: ProcessToken, previousFlowNodeInstanceIds?: Array<string>): Promise<void> {
+
+    const previousFlowNodeInstanceIdToPersist = previousFlowNodeInstanceIds
+      ? previousFlowNodeInstanceIds.join(';')
+      : this.previousFlowNodeInstanceId;
+
+    await this.flowNodePersistenceFacade.persistOnEnter(this.flowNode, this.flowNodeInstanceId, processToken, previousFlowNodeInstanceIdToPersist);
   }
 
   protected async persistOnExit(processToken: ProcessToken): Promise<void> {

--- a/src/runtime/flow_node_handler/flow_node_handler.ts
+++ b/src/runtime/flow_node_handler/flow_node_handler.ts
@@ -277,14 +277,14 @@ export abstract class FlowNodeHandler<TFlowNode extends Model.Base.FlowNode> imp
       ? nextFlowNodeInstance.id
       : nextFlowNodeHandler.getInstanceId();
 
-    // An instance for the next FlowNode has already been created. Continue resuming
+    // Providing FlowNodeInstances means that we are resuming a process.
+    // Normal process execution doesn't know about any FlowNodeInstances.
     if (nextFlowNodeInstance) {
       return nextFlowNodeHandler
         .resume(nextFlowNodeInstance, allFlowNodeInstances, processTokenFacade, processModelFacade, identity);
     }
 
-    // No instance for the next FlowNode was found.
-    // We have arrived at the point at which the ProcessInstance was interrupted and can continue normally.
+    // No FlowNodeInstance is given. The Process is executed normally.
     return nextFlowNodeHandler
       .execute(processToken, processTokenFacade, processModelFacade, identity, this.flowNodeInstanceId);
   }

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -8,7 +8,6 @@ import {
   ProcessTokenType,
 } from '@process-engine/flow_node_instance.contracts';
 import {
-  IFlowNodeInstanceResult,
   IProcessModelFacade,
   IProcessTokenFacade,
 } from '@process-engine/process_engine_contracts';
@@ -27,10 +26,10 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
   ): Promise<void> {
 
     return new Promise<void>(async (resolve: Function, reject: Function): Promise<void> => {
-      try {
-        this.previousFlowNodeInstanceId = previousFlowNodeInstanceId;
-        token.flowNodeInstanceId = this.flowNodeInstanceId;
+      this.previousFlowNodeInstanceId = previousFlowNodeInstanceId;
+      token.flowNodeInstanceId = this.flowNodeInstanceId;
 
+      try {
         this.terminationSubscription = this.subscribeToProcessTermination(token, reject);
 
         await this.beforeExecute(token, processTokenFacade, processModelFacade, identity);
@@ -40,11 +39,12 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
         const nextFlowNodesFound = nextFlowNodes && nextFlowNodes.length > 0;
         if (nextFlowNodesFound) {
 
-          const executeNextFlowNode = async (nextFlowNode: Model.Base.FlowNode): Promise<void> => {
-            const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, token);
+          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
+
+          for (const nextFlowNode of nextFlowNodes) {
 
             // If we must execute multiple branches, then each branch must get its own ProcessToken and Facade.
-            const tokenForNextFlowNode = nextFlowNodes.length > 1
+            const processTokenForBranch = nextFlowNodes.length > 1
               ? processTokenFacade.createProcessToken(token.payload)
               : token;
 
@@ -52,15 +52,14 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
               ? processTokenFacade.getProcessTokenFacadeForParallelBranch()
               : processTokenFacade;
 
-            tokenForNextFlowNode.flowNodeInstanceId = nextFlowNodeHandler.getInstanceId();
-
-            return nextFlowNodeHandler
-              .execute(tokenForNextFlowNode, processTokenFacadeForFlowNode, processModelFacade, identity, this.flowNodeInstanceId);
-          };
-
-          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
-          for (const nextFlowNode of nextFlowNodes) {
-            nextFlowNodeExecutionPromises.push(executeNextFlowNode(nextFlowNode));
+            const handleNextFlowNodePromise = this.handleNextFlowNode(
+              nextFlowNode,
+              processTokenFacadeForFlowNode,
+              processModelFacade,
+              processTokenForBranch,
+              identity,
+            );
+            nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);
@@ -68,19 +67,7 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
 
         return resolve();
       } catch (error) {
-
-        token.payload = error;
-
-        const allResults = processTokenFacade.getAllResults();
-        // This check is necessary to prevent duplicate entries, in case the Promise-Chain was broken further down the road.
-        const noResultStoredYet = !allResults.some((entry: IFlowNodeInstanceResult): boolean => entry.flowNodeInstanceId === this.flowNodeInstanceId);
-        if (noResultStoredYet) {
-          processTokenFacade.addResultForFlowNode(this.flowNode.id, this.flowNodeInstanceId, error);
-        }
-
-        await this.afterExecute(token);
-
-        return reject(error);
+        return this.handleError(token, error, processTokenFacade, reject);
       }
     });
   }
@@ -94,22 +81,20 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
   ): Promise<void> {
 
     return new Promise<void>(async (resolve: Function, reject: Function): Promise<void> => {
+
+      this.previousFlowNodeInstanceId = flowNodeInstanceForHandler.previousFlowNodeInstanceId;
+      this.flowNodeInstanceId = flowNodeInstanceForHandler.id;
+
+      // It doesn't really matter which token is used here, since payload-specific operations should
+      // only ever be done during the handlers execution.
+      // We only require the token here, so that we can pass infos like ProcessInstanceId or CorrelationId to the hook.
+      const token = flowNodeInstanceForHandler.tokens[0];
+
       try {
-        this.previousFlowNodeInstanceId = flowNodeInstanceForHandler.previousFlowNodeInstanceId;
-        this.flowNodeInstanceId = flowNodeInstanceForHandler.id;
-
-        // It doesn't really matter which token is used here, since payload-specific operations should
-        // only ever be done during the handlers execution.
-        // We only require the token here, so that we can pass infos like ProcessInstanceId or CorrelationId to the hook.
-        const token = flowNodeInstanceForHandler.tokens[0];
-
-        await this.beforeExecute(token, processTokenFacade, processModelFacade, identity);
-
         this.terminationSubscription = this.subscribeToProcessTermination(token, reject);
 
-        // With regards to ParallelGateways, we need to be able to handle multiple results here.
+        await this.beforeExecute(token, processTokenFacade, processModelFacade, identity);
         const nextFlowNodes = await this.resumeFromState(flowNodeInstanceForHandler, processTokenFacade, processModelFacade, identity);
-
         await this.afterExecute(token, processTokenFacade, processModelFacade, identity);
 
         const nextFlowNodesFound = nextFlowNodes && nextFlowNodes.length > 0;
@@ -119,7 +104,10 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
             .getAllResults()
             .pop();
 
-          const handleNextFlowNode = async (nextFlowNode: Model.Base.FlowNode): Promise<void> => {
+          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
+
+          for (const nextFlowNode of nextFlowNodes) {
+
             const processTokenForBranch = nextFlowNodes.length > 1
               ? processTokenFacade.createProcessToken(currentResult)
               : token;
@@ -128,42 +116,18 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
               ? processTokenFacade.getProcessTokenFacadeForParallelBranch()
               : processTokenFacade;
 
-            const nextFlowNodeInstance = allFlowNodeInstances.find((instance: FlowNodeInstance): boolean => {
+            const nextFlowNodeInstance = this.findNextInstanceOfFlowNode(allFlowNodeInstances, nextFlowNode.id);
 
-              // ParallelJoinGateways always have multiple "previousFlowNodeInstanceIds".
-              // These IDs are separated by ";", i.e.: ID1;ID2;ID3, etc.
-              // We need to account for that fact here.
-              // indexOf will return 0, if the two IDs are exact matches.
-              const instanceFollowedCurrentFlowNode =
-                instance.previousFlowNodeInstanceId &&
-                instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
-
-              const flowNodeIdsMatch = instance.flowNodeId === nextFlowNode.id;
-
-              return instanceFollowedCurrentFlowNode && flowNodeIdsMatch;
-            });
-
-            const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);
-
-            processTokenForBranch.flowNodeInstanceId = nextFlowNodeInstance
-              ? nextFlowNodeInstance.id
-              : nextFlowNodeHandler.getInstanceId();
-
-            // An instance for the next FlowNode has already been created. Continue resuming
-            if (nextFlowNodeInstance) {
-              return nextFlowNodeHandler
-                .resume(nextFlowNodeInstance, allFlowNodeInstances, processTokenFacadeForFlowNode, processModelFacade, identity);
-            }
-
-            // No instance for the next FlowNode was found.
-            // We have arrived at the point at which the ProcessInstance was interrupted and can continue normally.
-            return nextFlowNodeHandler
-              .execute(processTokenForBranch, processTokenFacadeForFlowNode, processModelFacade, identity, this.flowNodeInstanceId);
-          };
-
-          const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
-          for (const nextFlowNode of nextFlowNodes) {
-            nextFlowNodeExecutionPromises.push(handleNextFlowNode(nextFlowNode));
+            const handleNextFlowNodePromise = this.handleNextFlowNode(
+              nextFlowNode,
+              processTokenFacadeForFlowNode,
+              processModelFacade,
+              processTokenForBranch,
+              identity,
+              nextFlowNodeInstance,
+              allFlowNodeInstances,
+            );
+            nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);
@@ -171,22 +135,7 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
 
         return resolve();
       } catch (error) {
-
-        const token = processTokenFacade.createProcessToken();
-        token.payload = error;
-        token.flowNodeInstanceId = this.flowNodeInstanceId;
-
-        // This check is necessary to prevent duplicate entries, in case the Promise-Chain was broken further down the road.
-        const allResults = processTokenFacade.getAllResults();
-
-        const noResultStoredYet = !allResults.some((entry: IFlowNodeInstanceResult): boolean => entry.flowNodeInstanceId === this.flowNodeInstanceId);
-        if (noResultStoredYet) {
-          processTokenFacade.addResultForFlowNode(this.flowNode.id, this.flowNodeInstanceId, token);
-        }
-
-        await this.afterExecute(token);
-
-        return reject(error);
+        return this.handleError(token, error, processTokenFacade, reject);
       }
     });
   }

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -128,6 +128,16 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
               allFlowNodeInstances,
             );
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
+
+            // NOTE:
+            // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
+            // When multiple branches arrive at the JoinGateway at EXACT same moment, it is possible, that multiple instances for that same Gateway
+            // are registered at the Ioc container.
+            // Since the Gateway always waits for ALL incoming branches before moving on, this will result in the process instance getting stuck forever.
+            // This helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
+            if (nextFlowNodes.length > 1) {
+              await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 100));
+            }
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -133,7 +133,8 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
             // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
             // When multiple branches arrive at the JoinGateway at EXACT same moment, it is possible, that multiple instances for that same Gateway
             // are registered at the Ioc container.
-            // Since the Gateway always waits for ALL incoming branches before moving on, this will result in the process instance getting stuck forever.
+            // Since the Gateway always waits for ALL incoming branches before moving on,
+            // this will result in the process instance getting stuck forever.
             // This helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
             if (nextFlowNodes.length > 1) {
               await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 100));

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -36,8 +36,8 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
         const nextFlowNodes = await this.startExecution(token, processTokenFacade, processModelFacade, identity);
         await this.afterExecute(token, processTokenFacade, processModelFacade, identity);
 
-        const nextFlowNodesFound = nextFlowNodes && nextFlowNodes.length > 0;
-        if (nextFlowNodesFound) {
+        const processIsNotYetFinished = nextFlowNodes && nextFlowNodes.length > 0;
+        if (processIsNotYetFinished) {
 
           const nextFlowNodeExecutionPromises: Array<Promise<void>> = [];
 
@@ -97,8 +97,8 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
         const nextFlowNodes = await this.resumeFromState(flowNodeInstanceForHandler, processTokenFacade, processModelFacade, identity);
         await this.afterExecute(token, processTokenFacade, processModelFacade, identity);
 
-        const nextFlowNodesFound = nextFlowNodes && nextFlowNodes.length > 0;
-        if (nextFlowNodesFound) {
+        const processIsNotYetFinished = nextFlowNodes && nextFlowNodes.length > 0;
+        if (processIsNotYetFinished) {
 
           const currentResult = processTokenFacade
             .getAllResults()

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -131,17 +131,23 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
             const nextFlowNodeInstance = allFlowNodeInstances.find((instance: FlowNodeInstance): boolean => {
 
               // ParallelJoinGateways always have multiple "previousFlowNodeInstanceIds".
+              // These IDs are separated by ";", i.e.: ID1;ID2;ID3, etc.
               // We need to account for that fact here.
-              const previousFlowNodeInstanceIdIsACollection =
+              const previousFlowNodeInstanceIdIsAList =
                 instance.previousFlowNodeInstanceId &&
                 instance.previousFlowNodeInstanceId.indexOf(';') > -1;
 
-              if (previousFlowNodeInstanceIdIsACollection) {
+              if (previousFlowNodeInstanceIdIsAList) {
                 const deserializedPreviousFlowNodeInstanceIds = instance.previousFlowNodeInstanceId.split(';');
-                return deserializedPreviousFlowNodeInstanceIds.some((entry): boolean => entry === this.flowNodeInstanceId);
+                const instanceHasMatchingPreviousFlowNodeInstanceId = deserializedPreviousFlowNodeInstanceIds.some((entry): boolean => {
+                  return entry === this.flowNodeInstanceId;
+                });
+
+                return instanceHasMatchingPreviousFlowNodeInstanceId && instance.flowNodeId === nextFlowNode.id;
               }
 
-              return instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
+              return instance.flowNodeId === nextFlowNode.id &&
+                     instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
             });
 
             const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -86,7 +86,7 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
       this.flowNodeInstanceId = flowNodeInstanceForHandler.id;
 
       // It doesn't really matter which token is used here, since payload-specific operations should
-      // only ever be done during the handlers execution.
+      // only ever be done during the handler's execution.
       // We only require the token here, so that we can pass infos like ProcessInstanceId or CorrelationId to the hook.
       const token = flowNodeInstanceForHandler.tokens[0];
 
@@ -130,8 +130,8 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
 
             // NOTE:
-            // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
-            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible,
+            // This is a workaround for a problem with the resumption of multiple parallel branches that were executed right up to the JoinGateway.
+            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible
             // that multiple instances for that same Gateway are created.
             // Since the Gateway always waits for ALL incoming branches before moving on,
             // this will result in the process instance getting stuck forever.

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -131,11 +131,11 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
 
             // NOTE:
             // This is a workaround for a Problem with the resumption of multiple parallel branches that were executed right up to the Join-gateway.
-            // When multiple branches arrive at the JoinGateway at EXACT same moment, it is possible, that multiple instances for that same Gateway
-            // are registered at the Ioc container.
+            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible,
+            // that multiple instances for that same Gateway are created.
             // Since the Gateway always waits for ALL incoming branches before moving on,
             // this will result in the process instance getting stuck forever.
-            // This helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
+            // Using a timeout helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
             if (nextFlowNodes.length > 1) {
               await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 100));
             }

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -134,7 +134,10 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
               // These IDs are separated by ";", i.e.: ID1;ID2;ID3, etc.
               // We need to account for that fact here.
               // indexOf will return 0, if the two IDs are exact matches.
-              const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
+              const instanceFollowedCurrentFlowNode =
+                instance.previousFlowNodeInstanceId &&
+                instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
+
               const flowNodeIdsMatch = instance.flowNodeId === nextFlowNode.id;
 
               return instanceFollowedCurrentFlowNode && flowNodeIdsMatch;

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -138,12 +138,9 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
                 instance.previousFlowNodeInstanceId.indexOf(';') > -1;
 
               if (previousFlowNodeInstanceIdIsAList) {
-                const deserializedPreviousFlowNodeInstanceIds = instance.previousFlowNodeInstanceId.split(';');
-                const instanceHasMatchingPreviousFlowNodeInstanceId = deserializedPreviousFlowNodeInstanceIds.some((entry): boolean => {
-                  return entry === this.flowNodeInstanceId;
-                });
+                const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
 
-                return instanceHasMatchingPreviousFlowNodeInstanceId && instance.flowNodeId === nextFlowNode.id;
+                return instanceFollowedCurrentFlowNode && instance.flowNodeId === nextFlowNode.id;
               }
 
               return instance.flowNodeId === nextFlowNode.id &&

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -133,18 +133,11 @@ export abstract class GatewayHandler<TFlowNode extends Model.Base.FlowNode> exte
               // ParallelJoinGateways always have multiple "previousFlowNodeInstanceIds".
               // These IDs are separated by ";", i.e.: ID1;ID2;ID3, etc.
               // We need to account for that fact here.
-              const previousFlowNodeInstanceIdIsAList =
-                instance.previousFlowNodeInstanceId &&
-                instance.previousFlowNodeInstanceId.indexOf(';') > -1;
+              // indexOf will return 0, if the two IDs are exact matches.
+              const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
+              const flowNodeIdsMatch = instance.flowNodeId === nextFlowNode.id;
 
-              if (previousFlowNodeInstanceIdIsAList) {
-                const instanceFollowedCurrentFlowNode = instance.previousFlowNodeInstanceId.indexOf(this.flowNodeInstanceId) > -1;
-
-                return instanceFollowedCurrentFlowNode && instance.flowNodeId === nextFlowNode.id;
-              }
-
-              return instance.flowNodeId === nextFlowNode.id &&
-                     instance.previousFlowNodeInstanceId === this.flowNodeInstanceId;
+              return instanceFollowedCurrentFlowNode && flowNodeIdsMatch;
             });
 
             const nextFlowNodeHandler = await this.flowNodeHandlerFactory.create<Model.Base.FlowNode>(nextFlowNode, processTokenForBranch);

--- a/src/runtime/flow_node_handler/gateway_handler/parallel_join_gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/parallel_join_gateway_handler.ts
@@ -62,7 +62,7 @@ export class ParallelJoinGatewayHandler extends GatewayHandler<Model.Gateways.Pa
 
     // TODO: Works for now, but there really must be a better solution for this problem.
     //
-    // The base ID gets overwritten, each time an incoming SequenceFlow arrives.
+    // The base ID gets overwritten each time an incoming SequenceFlow arrives.
     // So with each execution of this hook, we get an additional ID of one of
     // the preceeding FlowNodeInstances.
     // Since we must store ALL previousFlowNodeInstanceIds for the gateway,

--- a/src/runtime/flow_node_handler/gateway_handler/parallel_join_gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/parallel_join_gateway_handler.ts
@@ -53,11 +53,8 @@ export class ParallelJoinGatewayHandler extends GatewayHandler<Model.Gateways.Pa
     identity: IIdentity,
   ): Promise<void> {
 
-    const expectedResultsAlreadySet = this.expectedNumberOfResults > -1;
-
     // Safety check to prevent a handler to be resolved and called after it was already finished.
-    const handlerIsAlreadyFinished = expectedResultsAlreadySet || this.isInterrupted;
-    if (handlerIsAlreadyFinished) {
+    if (this.isInterrupted) {
       return;
     }
 
@@ -82,8 +79,11 @@ export class ParallelJoinGatewayHandler extends GatewayHandler<Model.Gateways.Pa
       this.processTerminationSubscription = this.subscribeToProcessTermination(token);
     }
 
-    const preceedingFlowNodes = processModelFacade.getPreviousFlowNodesFor(this.parallelGateway);
-    this.expectedNumberOfResults = preceedingFlowNodes.length;
+    const expectedNumerOfResultsNotset = this.expectedNumberOfResults === -1;
+    if (expectedNumerOfResultsNotset) {
+      const preceedingFlowNodes = processModelFacade.getPreviousFlowNodesFor(this.parallelGateway);
+      this.expectedNumberOfResults = preceedingFlowNodes.length;
+    }
   }
 
   protected async startExecution(

--- a/src/runtime/flow_node_handler/gateway_handler/parallel_join_gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/parallel_join_gateway_handler.ts
@@ -99,11 +99,7 @@ export class ParallelJoinGatewayHandler extends GatewayHandler<Model.Gateways.Pa
 
     this.logger.verbose(`Executing ParallelJoinGateway instance ${this.flowNodeInstanceId}.`);
 
-    const allPreviousFlowNodeInstanceIdsStored = this.incomingFlowNodeInstanceIds.length === this.expectedNumberOfResults;
-    if (allPreviousFlowNodeInstanceIdsStored) {
-      // We must only do the "onEnter" persistence, when we have ALL the IDs of the preceeding FlowNodeInstances.
-      await this.persistOnEnter(token, this.incomingFlowNodeInstanceIds);
-    }
+    await this.persistOnEnter(token, this.incomingFlowNodeInstanceIds);
 
     return this.executeHandler(token, processTokenFacade, processModelFacade, identity);
   }

--- a/src/runtime/flow_node_handler/gateway_handler/parallel_join_gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/parallel_join_gateway_handler.ts
@@ -62,13 +62,14 @@ export class ParallelJoinGatewayHandler extends GatewayHandler<Model.Gateways.Pa
 
     // TODO: Works for now, but there really must be a better solution for this problem.
     //
-    // This ID gets overriden, each time an incoming SequenceFlow arrives.
+    // The base ID gets overwritten, each time an incoming SequenceFlow arrives.
     // So with each execution of this hook, we get an additional ID of one of
     // the preceeding FlowNodeInstances.
     // Since we must store ALL previousFlowNodeInstanceIds for the gateway,
     // we'll add each ID to the `incomingFlowNodeInstanceIds`.
-    // When all Ids have been stored, the "persistOnEnter" gets all IDs as a concatenated string.
-    // This way, we can be sure that the `previousFlowNodeInstanceId` database field has all the relevant IDs.
+    // Each time a new ID is stored, `persistOnEnter` is called with the current amount of received IDs.
+    // This ensures that the FlowNodeInstance for this gateway will always have the most up to date info
+    // about which branches have arrived at the gateway.
     //
     // We must do it like this, or resuming the Join Gateway will have unpredictable results and will most
     // likely crash the ProcessInstance.


### PR DESCRIPTION
## Changes

1. Refactor `ParallelJoinGatewayHandler` so that it stores all its `previousFlowNodeInstanceIds`.
2. Move some commonly used functionality to the base `FlowNodeHandler` to improve readability and maintainability.
3. Account for multiple `previousFlowNodeInstanceIds` in the base FlowNodeHandlers during Process resumption.
4. Fix an issue where the content of the `ProcessTokenFacade` would get wiped whenever a FlowNodeInstance was resumed.
5. Fix an issue that caused multiple instances for the same ParallelJoinGateway to be created during the resumption of multiple parallel running branches.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/245

PR: #276

## How to test the changes

Resuming a ProcessInstance that got interrupted while executing parallel branches should now be possible.
