### PR TITLE
✨Additional notifications for activities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,8 @@ def cleanup_workspace() {
   }
 }
 
+def npm_install_command = 'npm install --ignore-scripts'
+
 pipeline {
   agent any
   tools {
@@ -30,10 +32,15 @@ pipeline {
           raw_package_version = sh(script: 'node --print --eval "require(\'./package.json\').version"', returnStdout: true).trim()
           package_version = raw_package_version.trim()
           echo("Package version is '${package_version}'")
+
+          def run_clean_install = env.BRANCH_NAME == 'master' || env.BRANCH_NAME == 'develop';
+          if (run_clean_install) {
+            npm_install_command = 'npm ci --ignore-scripts'
+          }
         }
         nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
           sh('node --version')
-          sh('npm ci --ignore-scripts')
+          sh(npm_install_command)
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@process-engine/flow_node_instance.contracts": "^2.0.0",
     "@process-engine/logging_api_contracts": "^1.0.0",
     "@process-engine/metrics_api_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "feature~additional_notifications_for_activities",
+    "@process-engine/process_engine_contracts": "45.0.0-4cd02bdc-b11",
     "@process-engine/process_model.contracts": "^2.3.0",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@process-engine/flow_node_instance.contracts": "^2.0.0",
     "@process-engine/logging_api_contracts": "^1.0.0",
     "@process-engine/metrics_api_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "^44.0.0",
+    "@process-engine/process_engine_contracts": "feature~additional_notifications_for_activities",
     "@process-engine/process_model.contracts": "^2.3.0",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -621,6 +621,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
       token.processInstanceId,
       this.flowNode.id,
       this.flowNodeInstanceId,
+      this.flowNode.bpmnType,
       identity,
       token.payload,
     );
@@ -636,6 +637,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
       token.processInstanceId,
       this.flowNode.id,
       this.flowNodeInstanceId,
+      this.flowNode.bpmnType,
       identity,
       token.payload,
     );

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -9,6 +9,8 @@ import {
   ProcessTokenType,
 } from '@process-engine/flow_node_instance.contracts';
 import {
+  ActivityFinishedMessage,
+  ActivityReachedMessage,
   IBoundaryEventHandler,
   IFlowNodeHandler,
   IFlowNodeInstanceResult,
@@ -609,6 +611,37 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
       await this.flowNodeHandlerFactory.create<TNextFlowNode>(nextFlowNode, currentProcessToken);
 
     return handlerForNextFlowNode.execute(currentProcessToken, processTokenFacade, processModelFacade, identity, boundaryInstanceId);
+  }
+
+  protected publishActivityReachedNotification(identity: IIdentity, token: ProcessToken): void {
+
+    const message = new ActivityReachedMessage(
+      token.correlationId,
+      token.processModelId,
+      token.processInstanceId,
+      this.flowNode.id,
+      this.flowNodeInstanceId,
+      identity,
+      token.payload,
+    );
+
+    this.eventAggregator.publish(eventAggregatorSettings.messagePaths.activityReached, message);
+  }
+
+  protected publishActivityFinishedNotification(identity: IIdentity, token: ProcessToken): void {
+
+    const message = new ActivityFinishedMessage(
+      token.correlationId,
+      token.processModelId,
+      token.processInstanceId,
+      this.flowNode.id,
+      this.flowNodeInstanceId,
+      identity,
+      token.payload,
+    );
+
+    // Global notification
+    this.eventAggregator.publish(eventAggregatorSettings.messagePaths.activityFinished, message);
   }
 
 }

--- a/src/runtime/flow_node_handler/activity_handler/call_activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/call_activity_handler.ts
@@ -6,8 +6,6 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {CorrelationProcessInstance, ICorrelationService} from '@process-engine/correlation.contracts';
 import {FlowNodeInstance, ProcessToken} from '@process-engine/flow_node_instance.contracts';
 import {
-  CallActivityFinishedMessage,
-  CallActivityReachedMessage,
   EndEventReachedMessage,
   IExecuteProcessService,
   IFlowNodeHandlerFactory,
@@ -84,7 +82,7 @@ export class CallActivityHandler extends ActivityHandler<Model.Activities.CallAc
 
       let callActivityResult: EndEventReachedMessage;
 
-      this.sendCallActivityReachedNotification(identity, onSuspendToken);
+      this.publishActivityReachedNotification(identity, onSuspendToken);
 
       const callActivityNotYetExecuted = matchingSubprocess === undefined;
       if (callActivityNotYetExecuted) {
@@ -102,11 +100,11 @@ export class CallActivityHandler extends ActivityHandler<Model.Activities.CallAc
       onSuspendToken.payload = this.createResultTokenPayloadFromCallActivityResult(callActivityResult);
 
       await this.persistOnResume(onSuspendToken);
+
       processTokenFacade.addResultForFlowNode(this.callActivity.id, this.flowNodeInstanceId, callActivityResult);
-
-      this.sendCallActivityFinishedNotification(identity, onSuspendToken);
-
       await this.persistOnExit(onSuspendToken);
+
+      this.publishActivityFinishedNotification(identity, onSuspendToken);
 
       return processModelFacade.getNextFlowNodesFor(this.callActivity);
     } catch (error) {
@@ -141,7 +139,7 @@ export class CallActivityHandler extends ActivityHandler<Model.Activities.CallAc
     try {
       const startEventId = await this.getAccessibleCallActivityStartEvent(identity);
 
-      this.sendCallActivityReachedNotification(identity, token);
+      this.publishActivityReachedNotification(identity, token);
 
       await this.persistOnSuspend(token);
 
@@ -150,10 +148,11 @@ export class CallActivityHandler extends ActivityHandler<Model.Activities.CallAc
       token.payload = this.createResultTokenPayloadFromCallActivityResult(callActivityResult);
 
       await this.persistOnResume(token);
+
       processTokenFacade.addResultForFlowNode(this.callActivity.id, this.flowNodeInstanceId, token.payload);
       await this.persistOnExit(token);
 
-      this.sendCallActivityFinishedNotification(identity, token);
+      this.publishActivityFinishedNotification(identity, token);
 
       return processModelFacade.getNextFlowNodesFor(this.callActivity);
     } catch (error) {
@@ -288,69 +287,6 @@ export class CallActivityHandler extends ActivityHandler<Model.Activities.CallAc
     this.eventAggregator.publish(eventName, message);
     // Global notification
     this.eventAggregator.publish(eventAggregatorSettings.messagePaths.processTerminated, message);
-  }
-
-  /**
-   * Publishes a notification on the EventAggregator, informing about a new
-   * suspended CallActivity.
-   *
-   * @param identity The identity that owns the CallActivity instance.
-   * @param token    Contains all the information required for the Notification message.
-   */
-  private sendCallActivityReachedNotification(identity: IIdentity, token: ProcessToken): void {
-
-    const message = new CallActivityReachedMessage(
-      token.correlationId,
-      token.processModelId,
-      token.processInstanceId,
-      this.callActivity.id,
-      this.flowNodeInstanceId,
-      identity,
-      token.payload,
-    );
-
-    this.eventAggregator.publish(eventAggregatorSettings.messagePaths.callActivityReached, message);
-  }
-
-  /**
-   * Publishes notifications on the EventAggregator, informing that a CallActivity
-   * has finished execution.
-   *
-   * Two notifications will be send:
-   * - A global notification that everybody can receive
-   * - A notification specifically for this CallActivity.
-   *
-   * @param identity The identity that owns the CallActivity instance.
-   * @param token    Contains all the information required for the notification message.
-   */
-  private sendCallActivityFinishedNotification(identity: IIdentity, token: ProcessToken): void {
-
-    const message = new CallActivityFinishedMessage(
-      token.correlationId,
-      token.processModelId,
-      token.processInstanceId,
-      this.callActivity.id,
-      this.flowNodeInstanceId,
-      identity,
-      token.payload,
-    );
-
-    // FlowNode-specific notification
-    const callActivityFinishedEvent = this.getCallActivityFinishedEventName(token.correlationId, token.processInstanceId);
-    this.eventAggregator.publish(callActivityFinishedEvent, message);
-
-    // Global notification
-    this.eventAggregator.publish(eventAggregatorSettings.messagePaths.callActivityFinished, message);
-  }
-
-  private getCallActivityFinishedEventName(correlationId: string, processInstanceId: string): string {
-
-    const callActivityFinishedEvent = eventAggregatorSettings.messagePaths.callActivityFinished
-      .replace(eventAggregatorSettings.messageParams.correlationId, correlationId)
-      .replace(eventAggregatorSettings.messageParams.processInstanceId, processInstanceId)
-      .replace(eventAggregatorSettings.messageParams.flowNodeInstanceId, this.flowNodeInstanceId);
-
-    return callActivityFinishedEvent;
   }
 
 }

--- a/src/runtime/flow_node_handler/activity_handler/empty_activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/empty_activity_handler.ts
@@ -169,6 +169,7 @@ export class EmptyActivityHandler extends ActivityHandler<Model.Activities.Empty
       token.processInstanceId,
       this.emptyActivity.id,
       this.flowNodeInstanceId,
+      this.emptyActivity.bpmnType,
       identity,
       token.payload,
     );
@@ -184,6 +185,7 @@ export class EmptyActivityHandler extends ActivityHandler<Model.Activities.Empty
       token.processInstanceId,
       this.emptyActivity.id,
       this.flowNodeInstanceId,
+      this.emptyActivity.bpmnType,
       identity,
       token.payload,
     );

--- a/src/runtime/flow_node_handler/activity_handler/empty_activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/empty_activity_handler.ts
@@ -107,7 +107,7 @@ export class EmptyActivityHandler extends ActivityHandler<Model.Activities.Empty
 
       const waitForContinueEventPromise = await this.waitForFinishEvent(onSuspendToken);
 
-      this.publishEmptyTaskReachedNotification(identity, onSuspendToken);
+      this.publishEmptyActivityReachedNotification(identity, onSuspendToken);
 
       await waitForContinueEventPromise;
       await this.persistOnResume(onSuspendToken);
@@ -138,7 +138,7 @@ export class EmptyActivityHandler extends ActivityHandler<Model.Activities.Empty
     const waitForEmptyActivityResultPromise: Promise<any> = this.waitForFinishEvent(token);
     await this.persistOnSuspend(token);
 
-    this.publishEmptyTaskReachedNotification(identity, token);
+    this.publishEmptyActivityReachedNotification(identity, token);
 
     return waitForEmptyActivityResultPromise;
   }
@@ -161,7 +161,7 @@ export class EmptyActivityHandler extends ActivityHandler<Model.Activities.Empty
     });
   }
 
-  private publishEmptyTaskReachedNotification(identity: IIdentity, token: ProcessToken): void {
+  private publishEmptyActivityReachedNotification(identity: IIdentity, token: ProcessToken): void {
 
     const message = new ActivityReachedMessage(
       token.correlationId,

--- a/src/runtime/flow_node_handler/activity_handler/empty_activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/empty_activity_handler.ts
@@ -5,8 +5,8 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {FlowNodeInstance, ProcessToken} from '@process-engine/flow_node_instance.contracts';
 import {
-  EmptyActivityFinishedMessage,
-  EmptyActivityReachedMessage,
+  ActivityFinishedMessage,
+  ActivityReachedMessage,
   IFlowNodeHandlerFactory,
   IFlowNodePersistenceFacade,
   IProcessModelFacade,
@@ -75,7 +75,7 @@ export class EmptyActivityHandler extends ActivityHandler<Model.Activities.Empty
       processTokenFacade.addResultForFlowNode(this.emptyActivity.id, this.flowNodeInstanceId, token.payload);
       await this.persistOnExit(token);
 
-      this.sendEmptyActivityFinishedNotification(identity, token);
+      this.publishEmptyActivityFinishedNotification(identity, token);
 
       const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.emptyActivity);
 
@@ -107,7 +107,7 @@ export class EmptyActivityHandler extends ActivityHandler<Model.Activities.Empty
 
       const waitForContinueEventPromise = await this.waitForFinishEvent(onSuspendToken);
 
-      this.sendEmptyTaskReachedNotification(identity, onSuspendToken);
+      this.publishEmptyTaskReachedNotification(identity, onSuspendToken);
 
       await waitForContinueEventPromise;
       await this.persistOnResume(onSuspendToken);
@@ -115,7 +115,7 @@ export class EmptyActivityHandler extends ActivityHandler<Model.Activities.Empty
       processTokenFacade.addResultForFlowNode(this.emptyActivity.id, this.flowNodeInstanceId, onSuspendToken.payload);
       await this.persistOnExit(onSuspendToken);
 
-      this.sendEmptyActivityFinishedNotification(identity, onSuspendToken);
+      this.publishEmptyActivityFinishedNotification(identity, onSuspendToken);
 
       const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.emptyActivity);
 
@@ -138,7 +138,7 @@ export class EmptyActivityHandler extends ActivityHandler<Model.Activities.Empty
     const waitForEmptyActivityResultPromise: Promise<any> = this.waitForFinishEvent(token);
     await this.persistOnSuspend(token);
 
-    this.sendEmptyTaskReachedNotification(identity, token);
+    this.publishEmptyTaskReachedNotification(identity, token);
 
     return waitForEmptyActivityResultPromise;
   }
@@ -161,16 +161,9 @@ export class EmptyActivityHandler extends ActivityHandler<Model.Activities.Empty
     });
   }
 
-  /**
-   * Publishes a notification on the EventAggregator, informing about a new
-   * suspended EmptyActivity.
-   *
-   * @param identity The identity that owns the EmptyActivity instance.
-   * @param token    Contains all infos required for the Notification message.
-   */
-  private sendEmptyTaskReachedNotification(identity: IIdentity, token: ProcessToken): void {
+  private publishEmptyTaskReachedNotification(identity: IIdentity, token: ProcessToken): void {
 
-    const message = new EmptyActivityReachedMessage(
+    const message = new ActivityReachedMessage(
       token.correlationId,
       token.processModelId,
       token.processInstanceId,
@@ -183,20 +176,9 @@ export class EmptyActivityHandler extends ActivityHandler<Model.Activities.Empty
     this.eventAggregator.publish(eventAggregatorSettings.messagePaths.emptyActivityReached, message);
   }
 
-  /**
-   * Publishes notifications on the EventAggregator, informing that an EmptyActivity
-   * has finished execution.
-   *
-   * Two notifications will be send:
-   * - A global notification that everybody can receive
-   * - A notification specifically for this EmptyActivity.
-   *
-   * @param identity The identity that owns the EmptyActivity instance.
-   * @param token    Contains all infos required for the Notification message.
-   */
-  private sendEmptyActivityFinishedNotification(identity: IIdentity, token: ProcessToken): void {
+  private publishEmptyActivityFinishedNotification(identity: IIdentity, token: ProcessToken): void {
 
-    const message = new EmptyActivityFinishedMessage(
+    const message = new ActivityFinishedMessage(
       token.correlationId,
       token.processModelId,
       token.processInstanceId,

--- a/src/runtime/flow_node_handler/activity_handler/manual_task_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/manual_task_handler.ts
@@ -5,13 +5,13 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {FlowNodeInstance, ProcessToken} from '@process-engine/flow_node_instance.contracts';
 import {
+  ActivityFinishedMessage,
+  ActivityReachedMessage,
   FinishManualTaskMessage,
   IFlowNodeHandlerFactory,
   IFlowNodePersistenceFacade,
   IProcessModelFacade,
   IProcessTokenFacade,
-  ManualTaskFinishedMessage,
-  ManualTaskReachedMessage,
   eventAggregatorSettings,
 } from '@process-engine/process_engine_contracts';
 import {Model} from '@process-engine/process_model.contracts';
@@ -76,7 +76,7 @@ export class ManualTaskHandler extends ActivityHandler<Model.Activities.ManualTa
       processTokenFacade.addResultForFlowNode(this.manualTask.id, this.flowNodeInstanceId, manualTaskResult);
       await this.persistOnExit(token);
 
-      this.sendManualTaskFinishedNotification(identity, token);
+      this.publishManualTaskFinishedNotification(identity, token);
 
       const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.manualTask);
 
@@ -108,7 +108,7 @@ export class ManualTaskHandler extends ActivityHandler<Model.Activities.ManualTa
 
       const waitForMessagePromise = await this.waitForManualTaskResult(identity, onSuspendToken);
 
-      this.sendManualTaskReachedNotification(identity, onSuspendToken);
+      this.publishManualTaskReachedNotification(identity, onSuspendToken);
 
       const manualTaskResult = await waitForMessagePromise;
 
@@ -119,7 +119,7 @@ export class ManualTaskHandler extends ActivityHandler<Model.Activities.ManualTa
       processTokenFacade.addResultForFlowNode(this.manualTask.id, this.flowNodeInstanceId, manualTaskResult);
       await this.persistOnExit(onSuspendToken);
 
-      this.sendManualTaskFinishedNotification(identity, onSuspendToken);
+      this.publishManualTaskFinishedNotification(identity, onSuspendToken);
 
       const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.manualTask);
 
@@ -144,7 +144,7 @@ export class ManualTaskHandler extends ActivityHandler<Model.Activities.ManualTa
     const waitForManualTaskResultPromise = this.waitForManualTaskResult(identity, token);
     await this.persistOnSuspend(token);
 
-    this.sendManualTaskReachedNotification(identity, token);
+    this.publishManualTaskReachedNotification(identity, token);
 
     return waitForManualTaskResultPromise;
   }
@@ -175,16 +175,9 @@ export class ManualTaskHandler extends ActivityHandler<Model.Activities.ManualTa
     });
   }
 
-  /**
-   * Publishes a notification on the EventAggregator, informing about a new
-   * suspended ManualTask.
-   *
-   * @param identity The identity that owns the ManualTask instance.
-   * @param token    Contains all infos required for the Notification message.
-   */
-  private sendManualTaskReachedNotification(identity: IIdentity, token: ProcessToken): void {
+  private publishManualTaskReachedNotification(identity: IIdentity, token: ProcessToken): void {
 
-    const message = new ManualTaskReachedMessage(
+    const message = new ActivityReachedMessage(
       token.correlationId,
       token.processModelId,
       token.processInstanceId,
@@ -197,20 +190,9 @@ export class ManualTaskHandler extends ActivityHandler<Model.Activities.ManualTa
     this.eventAggregator.publish(eventAggregatorSettings.messagePaths.manualTaskReached, message);
   }
 
-  /**
-   * Publishes notifications on the EventAggregator, informing that a ManualTask
-   * has finished execution.
-   *
-   * Two notifications will be send:
-   * - A global notification that everybody can receive
-   * - A notification specifically for this ManualTask.
-   *
-   * @param identity The identity that owns the ManualTask instance.
-   * @param token    Contains all infos required for the Notification message.
-   */
-  private sendManualTaskFinishedNotification(identity: IIdentity, token: ProcessToken): void {
+  private publishManualTaskFinishedNotification(identity: IIdentity, token: ProcessToken): void {
 
-    const message = new ManualTaskFinishedMessage(
+    const message = new ActivityFinishedMessage(
       token.correlationId,
       token.processModelId,
       token.processInstanceId,

--- a/src/runtime/flow_node_handler/activity_handler/manual_task_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/manual_task_handler.ts
@@ -183,6 +183,7 @@ export class ManualTaskHandler extends ActivityHandler<Model.Activities.ManualTa
       token.processInstanceId,
       this.manualTask.id,
       this.flowNodeInstanceId,
+      this.manualTask.bpmnType,
       identity,
       token.payload,
     );
@@ -198,6 +199,7 @@ export class ManualTaskHandler extends ActivityHandler<Model.Activities.ManualTa
       token.processInstanceId,
       this.manualTask.id,
       this.flowNodeInstanceId,
+      this.manualTask.bpmnType,
       identity,
       token.payload,
     );

--- a/src/runtime/flow_node_handler/activity_handler/receive_task_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/receive_task_handler.ts
@@ -80,15 +80,20 @@ export class ReceiveTaskHandler extends ActivityHandler<Model.Activities.Receive
         return undefined;
       };
 
+      this.publishActivityReachedNotification(identity, token);
+
       const receivedMessage = await executionPromise;
 
       token.payload = receivedMessage.currentToken;
 
       await this.persistOnResume(token);
+
       this.sendReplyToSender(identity, token);
 
       processTokenFacade.addResultForFlowNode(this.receiveTask.id, this.flowNodeInstanceId, receivedMessage.currentToken);
       await this.persistOnExit(receivedMessage.currentToken);
+
+      this.publishActivityFinishedNotification(identity, token);
 
       const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.receiveTask);
 

--- a/src/runtime/flow_node_handler/activity_handler/send_task_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/send_task_handler.ts
@@ -83,10 +83,14 @@ export class SendTaskHandler extends ActivityHandler<Model.Activities.SendTask> 
         await this.persistOnResume(token);
         await this.persistOnExit(token);
 
+        this.publishActivityFinishedNotification(identity, token);
+
         const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.sendTask);
 
         return resolve(nextFlowNodeInfo);
       };
+
+      this.publishActivityReachedNotification(identity, token);
 
       this.waitForResponseFromReceiveTask(onResponseReceivedCallback);
       this.sendMessage(identity, token);

--- a/src/runtime/flow_node_handler/activity_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/service_task_handlers/external_service_task_handler.ts
@@ -102,6 +102,8 @@ export class ExternalServiceTaskHandler extends ActivityHandler<Model.Activities
         return undefined;
       };
 
+      this.publishActivityReachedNotification(identity, onSuspendToken);
+
       const externalTask = await this.getExternalTaskForFlowNodeInstance(flowNodeInstance);
 
       const noMatchingExteralTaskExists = !externalTask;
@@ -114,6 +116,8 @@ export class ExternalServiceTaskHandler extends ActivityHandler<Model.Activities
         await this.persistOnExit(onSuspendToken);
 
         const nextFlowNode = processModelFacade.getNextFlowNodesFor(this.serviceTask);
+
+        this.publishActivityFinishedNotification(identity, onSuspendToken);
 
         return resolve(nextFlowNode);
       }
@@ -129,6 +133,8 @@ export class ExternalServiceTaskHandler extends ActivityHandler<Model.Activities
         // We must wait for the notification and pass the result to our customized callback.
         this.waitForExternalTaskResult(processExternalTaskResult);
       }
+
+      this.publishActivityFinishedNotification(identity, onSuspendToken);
     });
 
     return resumerPromise;
@@ -155,6 +161,9 @@ export class ExternalServiceTaskHandler extends ActivityHandler<Model.Activities
 
           return undefined;
         };
+
+        this.publishActivityReachedNotification(identity, token);
+
         const result = await this.executeExternalServiceTask(token, processTokenFacade, identity);
 
         processTokenFacade.addResultForFlowNode(this.serviceTask.id, this.flowNodeInstanceId, result);
@@ -163,6 +172,8 @@ export class ExternalServiceTaskHandler extends ActivityHandler<Model.Activities
         await this.persistOnExit(token);
 
         const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.serviceTask);
+
+        this.publishActivityFinishedNotification(identity, token);
 
         return resolve(nextFlowNodeInfo);
       } catch (error) {

--- a/src/runtime/flow_node_handler/activity_handler/service_task_handlers/internal_service_task_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/service_task_handlers/internal_service_task_handler.ts
@@ -56,6 +56,8 @@ export class InternalServiceTaskHandler extends ActivityHandler<Model.Activities
     identity: IIdentity,
   ): Promise<Array<Model.Base.FlowNode>> {
 
+    this.publishActivityReachedNotification(identity, token);
+
     const serviceTaskHasNoInvocation = this.serviceTask.invocation === undefined;
     if (serviceTaskHasNoInvocation) {
       this.logger.verbose('ServiceTask has no invocation. Skipping execution.');
@@ -66,6 +68,8 @@ export class InternalServiceTaskHandler extends ActivityHandler<Model.Activities
       await this.persistOnExit(token);
 
       const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.serviceTask);
+
+      this.publishActivityFinishedNotification(identity, token);
 
       return nextFlowNodeInfo;
     }
@@ -91,6 +95,8 @@ export class InternalServiceTaskHandler extends ActivityHandler<Model.Activities
         await this.persistOnExit(token);
 
         const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.serviceTask);
+
+        this.publishActivityFinishedNotification(identity, token);
 
         return resolve(nextFlowNodeInfo);
       } catch (error) {

--- a/src/runtime/flow_node_handler/activity_handler/sub_process_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/sub_process_handler.ts
@@ -94,6 +94,8 @@ export class SubProcessHandler extends ActivityHandler<Model.Activities.SubProce
           return undefined;
         };
 
+        this.publishActivityReachedNotification(identity, onSuspendToken);
+
         const subProcessWasNotStarted = flowNodeInstancesForSubprocessInstance.length === 0;
         const subProcessResult = subProcessWasNotStarted
           ? await this.waitForSubProcessExecution(processInstanceConfig, identity)
@@ -104,6 +106,8 @@ export class SubProcessHandler extends ActivityHandler<Model.Activities.SubProce
 
         processTokenFacade.addResultForFlowNode(this.subProcess.id, this.flowNodeInstanceId, subProcessResult);
         await this.persistOnExit(onSuspendToken);
+
+        this.publishActivityFinishedNotification(identity, onSuspendToken);
 
         const nextFlowNodes = processModelFacade.getNextFlowNodesFor(this.subProcess);
 
@@ -153,6 +157,8 @@ export class SubProcessHandler extends ActivityHandler<Model.Activities.SubProce
           return undefined;
         };
 
+        this.publishActivityReachedNotification(identity, token);
+
         await this.persistOnSuspend(token);
         const subProcessResult = await this.waitForSubProcessExecution(processInstanceConfig, identity);
         token.payload = subProcessResult;
@@ -160,6 +166,8 @@ export class SubProcessHandler extends ActivityHandler<Model.Activities.SubProce
 
         processTokenFacade.addResultForFlowNode(this.subProcess.id, this.flowNodeInstanceId, subProcessResult);
         await this.persistOnExit(token);
+
+        this.publishActivityFinishedNotification(identity, token);
 
         const nextFlowNodes = processModelFacade.getNextFlowNodesFor(this.subProcess);
 

--- a/src/runtime/flow_node_handler/activity_handler/user_task_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/user_task_handler.ts
@@ -80,7 +80,7 @@ export class UserTaskHandler extends ActivityHandler<Model.Activities.UserTask> 
         processTokenFacade.addResultForFlowNode(this.userTask.id, this.flowNodeInstanceId, userTaskResult);
         await this.persistOnExit(token);
 
-        this.sendUserTaskFinishedNotification(identity, token);
+        this.publishUserTaskFinishedNotification(identity, token);
 
         const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.userTask);
 
@@ -117,7 +117,7 @@ export class UserTaskHandler extends ActivityHandler<Model.Activities.UserTask> 
 
       const waitForMessagePromise = this.waitForUserTaskResult(identity, onSuspendToken);
 
-      this.sendUserTaskReachedNotification(identity, onSuspendToken);
+      this.publishUserTaskReachedNotification(identity, onSuspendToken);
 
       const userTaskResult = await waitForMessagePromise;
 
@@ -128,7 +128,7 @@ export class UserTaskHandler extends ActivityHandler<Model.Activities.UserTask> 
       processTokenFacade.addResultForFlowNode(this.userTask.id, this.flowNodeInstanceId, userTaskResult);
       await this.persistOnExit(onSuspendToken);
 
-      this.sendUserTaskFinishedNotification(identity, onSuspendToken);
+      this.publishUserTaskFinishedNotification(identity, onSuspendToken);
 
       const nextFlowNodeInfo = processModelFacade.getNextFlowNodesFor(this.userTask);
 
@@ -218,7 +218,7 @@ export class UserTaskHandler extends ActivityHandler<Model.Activities.UserTask> 
     const waitForUserTaskResultPromise = this.waitForUserTaskResult(identity, token);
     await this.persistOnSuspend(token);
 
-    this.sendUserTaskReachedNotification(identity, token);
+    this.publishUserTaskReachedNotification(identity, token);
 
     return waitForUserTaskResultPromise;
   }
@@ -253,14 +253,7 @@ export class UserTaskHandler extends ActivityHandler<Model.Activities.UserTask> 
     });
   }
 
-  /**
-   * Publishes a notification on the EventAggregator, informing about a new
-   * suspended UserTask.
-   *
-   * @param identity The identity that owns the UserTask instance.
-   * @param token    Contains all infos required for the Notification message.
-   */
-  private sendUserTaskReachedNotification(identity: IIdentity, token: ProcessToken): void {
+  private publishUserTaskReachedNotification(identity: IIdentity, token: ProcessToken): void {
 
     const message = new UserTaskReachedMessage(
       token.correlationId,
@@ -275,18 +268,7 @@ export class UserTaskHandler extends ActivityHandler<Model.Activities.UserTask> 
     this.eventAggregator.publish(eventAggregatorSettings.messagePaths.userTaskReached, message);
   }
 
-  /**
-   * Publishes notifications on the EventAggregator, informing that a UserTask
-   * has received a result and finished execution.
-   *
-   * Two notifications will be send:
-   * - A global notification that everybody can receive
-   * - A notification specifically for this UserTask.
-   *
-   * @param identity The identity that owns the UserTask instance.
-   * @param token    Contains all infos required for the Notification message.
-   */
-  private sendUserTaskFinishedNotification(identity: IIdentity, token: ProcessToken): void {
+  private publishUserTaskFinishedNotification(identity: IIdentity, token: ProcessToken): void {
 
     const message = new UserTaskFinishedMessage(
       token.payload,


### PR DESCRIPTION
## Changes

1. Add `publishActivityReachedNotification` and `publishActivityFinishedNotification` to the base ActivityHandler
2. Use these generic notification functions in the CallActivityHandler
3. Add these notifications to all remaining non-interactive ActivityHandlers (ScriptTask, ServiceTask, SendTask, ReceiveTask and Subprocess)
4. Refactor handlers EmptyActivities, UserTasks and ManualTasks to use the updated message types and notification naming schemas.
    - They will still follow their current notification pattern though, since it deviates from the pattern implemented in the base handler.
5. Only run `npm ci` during Jenkins builds, when building the develop or master branches.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/349

PR: #278
