### PR TITLE
✨ External task topics from token expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "12.8.0",
+  "version": "12.9.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",


### PR DESCRIPTION
## Changes

1. Allow ExternalTask topics to contain token expressions
2. Remove some useless code docs 
3. Move ExternalTask topic- and payload parsing to main `createExternalTask` function

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/347

PR: #279

## How to test the changes

- Create a ProcessModel with an ExternalTask that has a token expression as a topic (i.e. `token.history.someFlowNodeId.someReference`)
- Create an ExternalTask Worker that listens for the matching topic
- Run that ProcessModel
    - Make sure you pass the correct topic as an initial payload!
- See that the ExternalTask uses the correct topic and gets processed as expected