### PR TITLE
♻️ Move ExternalTask expression parsing to top of the handler

### DIFF
--- a/src/runtime/flow_node_handler/activity_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/service_task_handlers/external_service_task_handler.ts
@@ -154,12 +154,12 @@ export class ExternalServiceTaskHandler extends ActivityHandler<Model.Activities
 
         const topicHasTokenExpression = this.serviceTask.topic.indexOf('token.') > -1;
         if (topicHasTokenExpression) {
-          this.serviceTask.topic = this.getExternalTaskTopic(processTokenFacade);
+          this.serviceTask.topic = this.parseExternalTaskTopic(processTokenFacade);
         }
 
         const serviceTaskHasAttachedPayload = this.serviceTask.payload !== undefined;
         if (serviceTaskHasAttachedPayload) {
-          token.payload = this.getExternalTaskPayload(processTokenFacade, identity);
+          token.payload = this.parseExternalTaskPayload(processTokenFacade, identity);
         }
 
         await this.persistOnSuspend(token);
@@ -293,7 +293,7 @@ export class ExternalServiceTaskHandler extends ActivityHandler<Model.Activities
     );
   }
 
-  private getExternalTaskTopic(processTokenFacade: IProcessTokenFacade): any {
+  private parseExternalTaskTopic(processTokenFacade: IProcessTokenFacade): any {
 
     try {
       const tokenHistory = processTokenFacade.getOldTokenFormat();
@@ -309,7 +309,7 @@ export class ExternalServiceTaskHandler extends ActivityHandler<Model.Activities
     }
   }
 
-  private getExternalTaskPayload(processTokenFacade: IProcessTokenFacade, identity: IIdentity): any {
+  private parseExternalTaskPayload(processTokenFacade: IProcessTokenFacade, identity: IIdentity): any {
 
     try {
       const tokenHistory = processTokenFacade.getOldTokenFormat();


### PR DESCRIPTION
## Changes

1. Parsing ExternalTask topics and token payloads is now the first thing the handler does.
    - This allows the handler to detect configuration errors before anything actually happens.
    - It also fixes the referenced issue, where an ExternalTasks token expression was put into the created metrics, instead of the parsed payload.
2. Renamed the parser functions for topics and payloads to something more fitting.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/352

PR: #281

## How to test the changes

- Run a ProcessModel that uses ExternalTasks
- After the ExternalTask was run, examine the generated metrics for the ProcessModel
- See that ExternalTask's actual payload is put with the metrics, instead of the configured token expression
