### PR TITLE
✨Add getActiveCronjobs UseCase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -113,9 +113,9 @@
       }
     },
     "@process-engine/process_engine_contracts": {
-      "version": "45.1.0-05943492-b13",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_contracts/-/process_engine_contracts-45.1.0-05943492-b13.tgz",
-      "integrity": "sha512-C9i69R8lp9r+DaDMfvbkWzbLnGl3//7OSadyFTlfO8XtZnURq/Liw1f4wVjZ3yrkJasIPmjSKxOEeXA6r5tgvg==",
+      "version": "45.1.0-9e636160-b14",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_contracts/-/process_engine_contracts-45.1.0-9e636160-b14.tgz",
+      "integrity": "sha512-29PLFSXWWx3fZOuYzoyHG5GNIml8nBqBuABXiiaRB+ZeyjuKL1ZJBzBYPjc2WB9j45XRtD356k6DhRYSEBqxMA==",
       "requires": {
         "@essential-projects/event_aggregator_contracts": "^4.0.0",
         "@essential-projects/iam_contracts": "^3.4.2"
@@ -315,9 +315,9 @@
       }
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
+      "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -1605,9 +1605,9 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.25.tgz",
-      "integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz",
+      "integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
       "requires": {
         "moment": ">= 2.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@process-engine/flow_node_instance.contracts": "^2.0.0",
     "@process-engine/logging_api_contracts": "^1.0.0",
     "@process-engine/metrics_api_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "45.1.0-05943492-b13",
+    "@process-engine/process_engine_contracts": "feature~add_get_active_cronjobs_usecase",
     "@process-engine/process_model.contracts": "^2.3.0",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@process-engine/flow_node_instance.contracts": "^2.0.0",
     "@process-engine/logging_api_contracts": "^1.0.0",
     "@process-engine/metrics_api_contracts": "^1.0.0",
-    "@process-engine/process_engine_contracts": "feature~add_get_active_cronjobs_usecase",
+    "@process-engine/process_engine_contracts": "45.1.0-9e636160-b14",
     "@process-engine/process_model.contracts": "^2.3.0",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",

--- a/src/runtime/cronjob_service.ts
+++ b/src/runtime/cronjob_service.ts
@@ -114,10 +114,16 @@ export class CronjobService implements ICronjobService {
       const cronjobsForProcessModel = this.cronjobDictionary[processModelId];
 
       const cronjobConfigs = cronjobsForProcessModel.map((entry): CronjobConfiguration => {
+        const nextExecution = cronparser
+          .parseExpression(entry.cronjob)
+          .next()
+          .toDate();
+
         return {
           processModelId: processModelId,
           startEventId: entry.startEventId,
           crontab: entry.cronjob,
+          nextExecution: nextExecution,
         };
       });
       cronjobs = cronjobs.concat(...cronjobConfigs);

--- a/src/runtime/cronjob_service.ts
+++ b/src/runtime/cronjob_service.ts
@@ -5,6 +5,7 @@ import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity, IIdentityService} from '@essential-projects/iam_contracts';
 
 import {
+  CronjobConfiguration,
   ICronjobService,
   IExecuteProcessService,
   ITimerFacade,
@@ -97,6 +98,32 @@ export class CronjobService implements ICronjobService {
     this._isRunning = false;
 
     logger.info('Done.');
+  }
+
+  public getActive(): Array<CronjobConfiguration> {
+
+    const processModelsInStorage = Object.keys(this.cronjobDictionary);
+
+    if (processModelsInStorage.length === 0) {
+      return [];
+    }
+
+    let cronjobs: Array<CronjobConfiguration> = [];
+
+    for (const processModelId of processModelsInStorage) {
+      const cronjobsForProcessModel = this.cronjobDictionary[processModelId];
+
+      const cronjobConfigs = cronjobsForProcessModel.map((entry): CronjobConfiguration => {
+        return {
+          processModelId: processModelId,
+          startEventId: entry.startEventId,
+          cronjob: entry.cronjob,
+        };
+      });
+      cronjobs = cronjobs.concat(...cronjobConfigs);
+    }
+
+    return cronjobs;
   }
 
   public addOrUpdate(processModel: Model.Process): void {

--- a/src/runtime/cronjob_service.ts
+++ b/src/runtime/cronjob_service.ts
@@ -117,7 +117,7 @@ export class CronjobService implements ICronjobService {
         return {
           processModelId: processModelId,
           startEventId: entry.startEventId,
-          cronjob: entry.cronjob,
+          crontab: entry.cronjob,
         };
       });
       cronjobs = cronjobs.concat(...cronjobConfigs);


### PR DESCRIPTION
## Changes

1. Implement `getActive` UseCase for `CronjobService`

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/363

PR: #283

## How to test the changes

- Deploy some ProcessModels with cyclic `TimerStartEvents`
- Start the CronjobService
- Access `getActive` and see that a list with all cronjobs is returned