### PR TITLE
🐛 Fix ReceiveTask state transition to "finished"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "12.12.0",
+  "version": "12.12.1",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/execute_process_service.ts
+++ b/src/runtime/execute_process_service.ts
@@ -281,7 +281,6 @@ export class ExecuteProcessService implements IExecuteProcessService {
 
     const processToken = processTokenFacade.createProcessToken(payload);
     processToken.caller = caller;
-    processToken.payload = payload;
 
     const processInstanceConfig = {
       correlationId: correlationId,

--- a/src/runtime/flow_node_handler/activity_handler/receive_task_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/receive_task_handler.ts
@@ -88,7 +88,7 @@ export class ReceiveTaskHandler extends ActivityHandler<Model.Activities.Receive
       this.sendReplyToSender(identity, token);
 
       processTokenFacade.addResultForFlowNode(this.receiveTask.id, this.flowNodeInstanceId, receivedMessage.currentToken);
-      await this.persistOnExit(receivedMessage.currentToken);
+      await this.persistOnExit(token);
 
       this.publishActivityFinishedNotification(identity, token);
 


### PR DESCRIPTION
## Changes

1. Fix reference error in ReceiveTaskHandler's `persistOnExit` call
2. Remove duplicated initial token payload assignment

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/471

PR: #310

## How to test the changes

- Start a Process that uses a `SendTask` and `ReceiveTask`
- Don't attach any payloads to either task
- Start the process instance without any initial payload
- See that the message received by the `ReceiveTask` will have no payload
- See that the `ReceiveTask` is still able to change its state to `finished`