### PR TITLE
🔒 Use correct identity for terminating ProcessInstances manually

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
       }
     }
     stage('Install dependencies') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }
@@ -62,6 +63,7 @@ pipeline {
       }
     }
     stage('Build Sources') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }
@@ -71,6 +73,7 @@ pipeline {
       }
     }
     stage('Test') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }
@@ -90,6 +93,7 @@ pipeline {
       }
     }
     stage('Set package version') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }
@@ -99,6 +103,7 @@ pipeline {
       }
     }
     stage('Publish') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }
@@ -130,6 +135,7 @@ pipeline {
       }
     }
     stage('Cleanup') {
+      options {skipDefaultCheckout()}
       when {
         expression {buildIsRequired == true}
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "12.12.1",
+  "version": "12.13.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@essential-projects/timing_contracts": "^5.0.0",
     "@process-engine/logging_api_contracts": "^2.0.0",
     "@process-engine/persistence_api.contracts": "^1.1.0",
-    "@process-engine/process_engine_contracts": "^46.0.0",
+    "@process-engine/process_engine_contracts": "feature~add_identity_to_terminate_process_command",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",
     "addict-ioc": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@essential-projects/timing_contracts": "^5.0.0",
     "@process-engine/logging_api_contracts": "^2.0.0",
     "@process-engine/persistence_api.contracts": "^1.1.0",
-    "@process-engine/process_engine_contracts": "feature~add_identity_to_terminate_process_command",
+    "@process-engine/process_engine_contracts": "46.1.0-alpha.2",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",
     "addict-ioc": "^2.5.1",

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -261,27 +261,6 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
   }
 
   /**
-   * Publishes a notification on the EventAggregator, informing about a new
-   * reached IntermediateCatchEvent.
-   *
-   * @param token    Contains all the information required for the Notification message.
-   */
-  protected sendIntermediateCatchEventReachedNotification(token: ProcessToken): void {
-
-    const message = new IntermediateCatchEventReachedMessage(
-      token.correlationId,
-      token.processModelId,
-      token.processInstanceId,
-      this.flowNode.id,
-      this.flowNodeInstanceId,
-      undefined,
-      token.payload,
-    );
-
-    this.eventAggregator.publish(eventAggregatorSettings.messagePaths.intermediateCatchEventReached, message);
-  }
-
-  /**
    * Publishes a notification on the EventAggregator, informing about a
    * triggered IntermediateThrowEvent.
    *
@@ -300,6 +279,27 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
     );
 
     this.eventAggregator.publish(eventAggregatorSettings.messagePaths.intermediateThrowEventTriggered, message);
+  }
+
+  /**
+   * Publishes a notification on the EventAggregator, informing about a new
+   * reached IntermediateCatchEvent.
+   *
+   * @param token    Contains all the information required for the Notification message.
+   */
+  protected sendIntermediateCatchEventReachedNotification(token: ProcessToken): void {
+
+    const message = new IntermediateCatchEventReachedMessage(
+      token.correlationId,
+      token.processModelId,
+      token.processInstanceId,
+      this.flowNode.id,
+      this.flowNodeInstanceId,
+      undefined,
+      token.payload,
+    );
+
+    this.eventAggregator.publish(eventAggregatorSettings.messagePaths.intermediateCatchEventReached, message);
   }
 
   /**


### PR DESCRIPTION
## Changes

1. Attach a users identity to termination errors, if the Process was terminated by a user
2. Pass the terminating users identity to the CorrelationService, so claim checks will be performed against that identity instead
3. Log the name of the user that terminates a ProcessInstance

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/474

PR: #311

## How to test the changes

- Start a ProcessInstance
- Send a termination signal for that ProcessInstance, using a different identity as payload (Or use the `terminateProcessInstance` function of the Management API)
- See that all claim checks are performed against the identity that made the termination request