### PR TITLE
 ✨ Clear orphaned ProcessInstances on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_core",
-  "version": "12.13.1-alpha.1",
+  "version": "12.14.0",
   "description": "The ProcessEngine core package. ProcessEngine is a tool to bring BPMN diagrams to life in JS.",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/src/runtime/resume_process_serivce.ts
+++ b/src/runtime/resume_process_serivce.ts
@@ -266,7 +266,6 @@ export class ResumeProcessService implements IResumeProcessService {
 
     // Check for ProcessTermination
     const terminatedFlowNode = flowNodeInstances.find((fni): boolean => fni.state === FlowNodeInstanceState.terminated);
-
     if (terminatedFlowNode) {
       return terminatedFlowNode;
     }
@@ -274,8 +273,7 @@ export class ResumeProcessService implements IResumeProcessService {
     // Check for Errors
     const erroredFlowNode = flowNodeInstances.find((fni): boolean => fni.state === FlowNodeInstanceState.error);
 
-    // If none of the above happened, then some unknown error caused the ProcessInstance to become orphaned.
-    return erroredFlowNode ?? undefined;
+    return erroredFlowNode;
   }
 
 }

--- a/src/runtime/resume_process_serivce.ts
+++ b/src/runtime/resume_process_serivce.ts
@@ -245,11 +245,17 @@ export class ResumeProcessService implements IResumeProcessService {
       finalFlowNode?.state === FlowNodeInstanceState.terminated;
 
     if (processFinishedWithError) {
+      // Default error is used, if, for whatever reasons, no error is attached to the FlowNodeInstance.
+      // This was possible in older versions of the ProcessEngine.
+      const errorToUse = finalFlowNode.error ?? new InternalServerError('Process was terminated!');
+
       await this
         .correlationService
         // TODO: Fix type of `FlowNodeInstance.error` property
-        .finishProcessInstanceInCorrelationWithError(identity, processInstance.correlationId, processInstanceId, finalFlowNode.error as any);
+        .finishProcessInstanceInCorrelationWithError(identity, processInstance.correlationId, processInstanceId, errorToUse as any);
+
     } else {
+
       await this
         .correlationService
         .finishProcessInstanceInCorrelation(identity, processInstance.correlationId, processInstanceId);

--- a/src/runtime/resume_process_serivce.ts
+++ b/src/runtime/resume_process_serivce.ts
@@ -92,15 +92,15 @@ export class ResumeProcessService implements IResumeProcessService {
 
     // ----
     // First check if there even are any FlowNodeInstances still active for the ProcessInstance.
-    // There is no point in trying to resume anything that's already finished.
-    const processHasActiveFlowNodeInstances = flowNodeInstancesForProcessInstance.some((entry: FlowNodeInstance): boolean => {
+    // If no FlowNodeInstances are active anymore, then we are dealing with an orphaned ProcessInstance that we have to finish manually.
+    const processIsNotActiveAnymore = !flowNodeInstancesForProcessInstance.some((entry: FlowNodeInstance): boolean => {
       return entry.state === FlowNodeInstanceState.running || entry.state === FlowNodeInstanceState.suspended;
     });
 
-    if (!processHasActiveFlowNodeInstances) {
-      logger.info(`ProcessInstance ${processInstanceId} is not active anymore.`);
-
-      return undefined;
+    if (processIsNotActiveAnymore) {
+      logger.warn(`ProcessInstance ${processInstanceId} is not active anymore. It is likely something went wrong during final state transition.`);
+      logger.warn(`Setting orphaned ProcessInstance ${processInstanceId} state to "finished", so it won't show up again.`);
+      return this.finishOrphanedProcessInstance(identity, flowNodeInstancesForProcessInstance, processInstanceId);
     }
 
     return new Promise<EndEventReachedMessage>(async (resolve: Function, reject: Function): Promise<void> => {
@@ -227,6 +227,55 @@ export class ResumeProcessService implements IResumeProcessService {
 
       throw error;
     }
+  }
+
+  private async finishOrphanedProcessInstance(
+    identity: IIdentity,
+    flowNodeInstances: Array<FlowNodeInstance>,
+    processInstanceId: string,
+  ): Promise<EndEventReachedMessage> {
+
+    const processInstance = await this.correlationService.getByProcessInstanceId(identity, processInstanceId);
+
+    await this.correlationService.finishProcessInstanceInCorrelation(identity, processInstance.correlationId, processInstanceId);
+
+    const finalFlowNode = this.getFinalFlowNodeForOrphanedProcessInstance(flowNodeInstances);
+    const finalToken = finalFlowNode?.getTokenByType(ProcessTokenType.onExit).payload ?? undefined;
+
+    const result = new EndEventReachedMessage(
+      processInstance.correlationId,
+      processInstance.processModelId,
+      processInstanceId,
+      finalFlowNode?.flowNodeId,
+      finalFlowNode?.id,
+      processInstance.identity,
+      finalToken,
+      finalFlowNode?.flowNodeName,
+    );
+
+    return result;
+  }
+
+  private getFinalFlowNodeForOrphanedProcessInstance(flowNodeInstances: Array<FlowNodeInstance>): FlowNodeInstance {
+
+    // Check if the Instance was finished regularly by an EndEvent
+    const endEvent = flowNodeInstances.find((fni): boolean => fni.flowNodeType === BpmnType.endEvent);
+    if (endEvent) {
+      return endEvent;
+    }
+
+    // Check for ProcessTermination
+    const terminatedFlowNode = flowNodeInstances.find((fni): boolean => fni.state === FlowNodeInstanceState.terminated);
+
+    if (terminatedFlowNode) {
+      return terminatedFlowNode;
+    }
+
+    // Check for Errors
+    const erroredFlowNode = flowNodeInstances.find((fni): boolean => fni.state === FlowNodeInstanceState.error);
+
+    // If none of the above happened, then some unknown error caused the ProcessInstance to become orphaned.
+    return erroredFlowNode ?? undefined;
   }
 
 }

--- a/src/runtime/resume_process_serivce.ts
+++ b/src/runtime/resume_process_serivce.ts
@@ -240,7 +240,7 @@ export class ResumeProcessService implements IResumeProcessService {
     await this.correlationService.finishProcessInstanceInCorrelation(identity, processInstance.correlationId, processInstanceId);
 
     const finalFlowNode = this.getFinalFlowNodeForOrphanedProcessInstance(flowNodeInstances);
-    const finalToken = finalFlowNode?.getTokenByType(ProcessTokenType.onExit).payload ?? undefined;
+    const finalToken = finalFlowNode?.getTokenByType(ProcessTokenType.onExit)?.payload ?? {};
 
     const result = new EndEventReachedMessage(
       processInstance.correlationId,


### PR DESCRIPTION
## Changes

1. Check for orphaned ProcessInstances during initial ProcessInstance resumption
2. When dealing with terminated or errored ProcessInstances, use whichever FlowNode contains corresponding state as a baseline
    - Note that the result for `terminated` FlowNodes will always be the same, so it doesn't matter which of these FlowNodes is used
    - If the FlowNodeInstance has no error attached, a fallback error is used (this was possible in older versions, for which we must account here)
 
## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/486

PR: #315

## How to test the changes

- Run any kind of ProcessInstance and let it finish with varying results (success, ProcessTermination, or with an unhandled error on one of the FlowNodes)
- Manually set the state of the corresponding ProcessInstance to "running" (you'll have to do that in your database)
- Restart the ProcessEngine
- See that the ProcessInstance is recognized as orphaned and is cleaned up with a matching state.