### PR TITLE
🐛 Fix BoundaryEvent state transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/timing_contracts": "^5.0.0",
     "@process-engine/logging_api_contracts": "^2.0.0",
     "@process-engine/persistence_api.contracts": "^1.3.0",
-    "@process-engine/process_engine_contracts": "^46.1.0",
+    "@process-engine/process_engine_contracts": "47.0.0-alpha.1",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",
     "addict-ioc": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/timing_contracts": "^5.0.0",
     "@process-engine/logging_api_contracts": "^2.0.0",
     "@process-engine/persistence_api.contracts": "^1.3.0",
-    "@process-engine/process_engine_contracts": "47.0.0-alpha.2",
+    "@process-engine/process_engine_contracts": "47.0.0-alpha.3",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",
     "addict-ioc": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/timing_contracts": "^5.0.0",
     "@process-engine/logging_api_contracts": "^2.0.0",
     "@process-engine/persistence_api.contracts": "^1.3.0",
-    "@process-engine/process_engine_contracts": "47.0.0-alpha.1",
+    "@process-engine/process_engine_contracts": "47.0.0-alpha.2",
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",
     "addict-ioc": "^2.5.1",

--- a/src/runtime/facades/timer_facade.ts
+++ b/src/runtime/facades/timer_facade.ts
@@ -50,10 +50,12 @@ export class TimerFacade implements ITimerFacade {
   }
 
   public cancelTimerSubscription(subscription: Subscription): void {
-    const timerId = this.timerStorage[subscription.eventName];
-
     this.eventAggregator.unsubscribe(subscription);
-    this.timerService.cancel(timerId);
+
+    if (subscription?.eventName) {
+      const timerId = this.timerStorage[subscription.eventName];
+      this.timerService.cancel(timerId);
+    }
   }
 
   public startCycleTimer(timerValue: string, flowNode: Model.Base.FlowNode, timerCallback: Function, timerExpiredEventName: string): Subscription {

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -562,7 +562,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
     };
 
     if (flowNodeInstance) {
-      boundaryEventHandler.resumeWait(
+      await boundaryEventHandler.resumeWait(
         flowNodeInstance,
         onBoundaryEventTriggeredCallback,
         processToken,
@@ -571,7 +571,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
         this.flowNodeInstanceId,
       );
     } else {
-      boundaryEventHandler
+      await boundaryEventHandler
         .waitForTriggeringEvent(onBoundaryEventTriggeredCallback, processToken, processTokenFacade, processModelFacade, this.flowNodeInstanceId);
     }
 

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -551,7 +551,6 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
       await this.handleBoundaryEvent(eventData, currentProcessToken, processTokenFacade, processModelFacade, identity);
 
       if (eventData.interruptHandler) {
-        await this.interrupt(currentProcessToken);
         return handlerResolve(undefined);
       }
     };
@@ -588,6 +587,10 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
     if (eventData.eventPayload) {
       currentProcessToken.payload = eventData.eventPayload;
+    }
+
+    if (eventData.interruptHandler) {
+      await this.interrupt(currentProcessToken);
     }
 
     await this.continueAfterBoundaryEvent<typeof eventData.nextFlowNode>(

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -512,8 +512,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
     // Create a handler for each attached BoundaryEvent and store it in the internal collection.
     for (const model of boundaryEventModels) {
-
-      const flowNodeInstance = flowNodeInstances?.find((entry) => entry.flowNodeId === model.id && entry.state === FlowNodeInstanceState.running);
+      const flowNodeInstance = flowNodeInstances?.find((entry) => entry.flowNodeId === model.id && entry.previousFlowNodeInstanceId === this.flowNodeInstanceId);
       await this.createBoundaryEventHandler(model, processToken, processTokenFacade, processModelFacade, identity, handlerResolve, flowNodeInstance);
     }
   }

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -555,7 +555,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
       }
     };
 
-    await boundaryEventHandler
+    boundaryEventHandler
       .waitForTriggeringEvent(onBoundaryEventTriggeredCallback, currentProcessToken, processTokenFacade, processModelFacade, this.flowNodeInstanceId);
 
     this.attachedBoundaryEventHandlers.push(boundaryEventHandler);

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -512,7 +512,10 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
     // Create a handler for each attached BoundaryEvent and store it in the internal collection.
     for (const model of boundaryEventModels) {
-      const flowNodeInstance = flowNodeInstances?.find((entry) => entry.flowNodeId === model.id && entry.previousFlowNodeInstanceId === this.flowNodeInstanceId);
+      const flowNodeInstance = flowNodeInstances?.find((entry) => {
+        return entry.flowNodeId === model.id && entry.previousFlowNodeInstanceId === this.flowNodeInstanceId;
+      });
+
       await this.createBoundaryEventHandler(model, processToken, processTokenFacade, processModelFacade, identity, handlerResolve, flowNodeInstance);
     }
   }

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -275,8 +275,8 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
     processModelFacade?: IProcessModelFacade,
     identity?: IIdentity,
   ): Promise<void> {
-    await super.afterExecute(token, processTokenFacade, processModelFacade, identity);
     await this.detachBoundaryEvents(token, processModelFacade);
+    await super.afterExecute(token, processTokenFacade, processModelFacade, identity);
   }
 
   protected async continueAfterSuspend(
@@ -504,7 +504,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
     const boundaryEventModels = processModelFacade.getBoundaryEventsFor(this.flowNode);
 
-    const noBoundaryEventsFound = !boundaryEventModels || boundaryEventModels.length === 0;
+    const noBoundaryEventsFound = boundaryEventModels?.length === 0;
     if (noBoundaryEventsFound) {
       return;
     }

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -485,7 +485,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
    * Creates handlers for all BoundaryEvents attached this handler's FlowNode.
    *
    * @async
-   * @param currentProcessToken The current Processtoken.
+   * @param processToken        The current Processtoken.
    * @param processTokenFacade  The Facade for managing the ProcessInstance's
    *                            ProcessTokens.
    * @param processModelFacade  The ProcessModelFacade containing the ProcessModel.
@@ -495,7 +495,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
    *                            triggered.
    */
   private async attachBoundaryEvents(
-    currentProcessToken: ProcessToken,
+    processToken: ProcessToken,
     processTokenFacade: IProcessTokenFacade,
     processModelFacade: IProcessModelFacade,
     identity: IIdentity,
@@ -511,7 +511,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
     // Create a handler for each attached BoundaryEvent and store it in the internal collection.
     for (const model of boundaryEventModels) {
-      await this.createBoundaryEventHandler(model, currentProcessToken, processTokenFacade, processModelFacade, identity, handlerResolve);
+      await this.createBoundaryEventHandler(model, processToken, processTokenFacade, processModelFacade, identity, handlerResolve);
     }
   }
 
@@ -526,7 +526,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
   private findErrorBoundaryEventHandlersForError(error: Error, token: ProcessToken): Array<ErrorBoundaryEventHandler> {
     const errorBoundaryEventHandlers = this
       .attachedBoundaryEventHandlers
-      .filter((handler: IBoundaryEventHandler): boolean => handler instanceof ErrorBoundaryEventHandler) as Array<ErrorBoundaryEventHandler>;
+      .filter((handler): boolean => handler instanceof ErrorBoundaryEventHandler) as Array<ErrorBoundaryEventHandler>;
 
     const handlersForError =
       errorBoundaryEventHandlers.filter((handler: ErrorBoundaryEventHandler): boolean => handler.canHandleError(error as BpmnError, token));
@@ -536,7 +536,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
   private async createBoundaryEventHandler(
     boundaryEventModel: Model.Events.BoundaryEvent,
-    currentProcessToken: ProcessToken,
+    processToken: ProcessToken,
     processTokenFacade: IProcessTokenFacade,
     processModelFacade: IProcessModelFacade,
     identity: IIdentity,
@@ -548,7 +548,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
     const onBoundaryEventTriggeredCallback = async (eventData: OnBoundaryEventTriggeredData): Promise<void> => {
       // To prevent the Promise-chain from being broken too soon, we must first await the execution of the BoundaryEvent's execution path.
       // Interruption will already have happended, when this path is finished, so there is no danger of running this handler twice.
-      await this.handleBoundaryEvent(eventData, currentProcessToken, processTokenFacade, processModelFacade, identity);
+      await this.handleBoundaryEvent(eventData, processToken, processTokenFacade, processModelFacade, identity);
 
       if (eventData.interruptHandler) {
         return handlerResolve(undefined);
@@ -556,7 +556,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
     };
 
     boundaryEventHandler
-      .waitForTriggeringEvent(onBoundaryEventTriggeredCallback, currentProcessToken, processTokenFacade, processModelFacade, this.flowNodeInstanceId);
+      .waitForTriggeringEvent(onBoundaryEventTriggeredCallback, processToken, processTokenFacade, processModelFacade, this.flowNodeInstanceId);
 
     this.attachedBoundaryEventHandlers.push(boundaryEventHandler);
   }

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -442,7 +442,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
     processModelFacade: IProcessModelFacade,
   ): Array<IFlowNodeModelInstanceAssociation> {
 
-    const getBoundaryEventPreceedingFlowNodeInstance = (flowNodeInstance: FlowNodeInstance): Model.Events.BoundaryEvent => {
+    const getBoundaryEventPrecedingFlowNodeInstance = (flowNodeInstance: FlowNodeInstance): Model.Events.BoundaryEvent => {
       const matchingBoundaryEventInstance =
         flowNodeInstances.find((entry: FlowNodeInstance): boolean => entry.flowNodeId === flowNodeInstance.previousFlowNodeInstanceId);
 
@@ -470,7 +470,7 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
 
     const flowNodeModelInstanceAssociations = flowNodeInstancesAfterBoundaryEvents.map((fni: FlowNodeInstance): IFlowNodeModelInstanceAssociation => {
       return {
-        boundaryEventModel: getBoundaryEventPreceedingFlowNodeInstance(fni),
+        boundaryEventModel: getBoundaryEventPrecedingFlowNodeInstance(fni),
         nextFlowNodeInstance: fni,
         nextFlowNode: processModelFacade.getFlowNodeById(fni.flowNodeId),
       };

--- a/src/runtime/flow_node_handler/activity_handler/call_activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/call_activity_handler.ts
@@ -97,7 +97,7 @@ export class CallActivityHandler extends ActivityHandler<Model.Activities.CallAc
         callActivityResult = await this.executeSubprocess(identity, processTokenFacade, onSuspendToken);
       } else {
         // Subprocess was already started. Resume it and wait for the result:
-        callActivityResult = await this
+        callActivityResult = <EndEventReachedMessage> await this
           .resumeProcessService
           .resumeProcessInstanceById(identity, matchingSubprocess.processModelId, matchingSubprocess.processInstanceId);
       }
@@ -263,6 +263,10 @@ export class CallActivityHandler extends ActivityHandler<Model.Activities.CallAc
   }
 
   private createResultTokenPayloadFromCallActivityResult(result: EndEventReachedMessage): any {
+
+    if (!result) {
+      return {};
+    }
 
     const callActivityToken = result.currentToken;
 

--- a/src/runtime/flow_node_handler/activity_handler/service_task_handlers/external_service_task_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/service_task_handlers/external_service_task_handler.ts
@@ -146,6 +146,7 @@ export class ExternalServiceTaskHandler extends ActivityHandler<Model.Activities
 
       try {
         this.onInterruptedCallback = async (): Promise<void> => {
+          this.eventAggregator.unsubscribe(this.externalTaskSubscription);
           await this.abortExternalTask(token);
           handlerPromise.cancel();
         };
@@ -330,7 +331,7 @@ export class ExternalServiceTaskHandler extends ActivityHandler<Model.Activities
       return;
     }
 
-    const abortError = new InternalServerError('The ExternalTask was aborted, because the corresponding ProcessInstance was interrupted!');
+    const abortError = new InternalServerError('The ExternalTask was aborted, because the corresponding ServiceTask was interrupted!');
 
     await this.externalTaskRepository.finishWithError(matchingExternalTask.id, abortError);
   }

--- a/src/runtime/flow_node_handler/boundary_event_handler/boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/boundary_event_handler.ts
@@ -25,7 +25,7 @@ export abstract class BoundaryEventHandler implements IBoundaryEventHandler {
   protected readonly boundaryEventModel: Model.Events.BoundaryEvent;
   protected readonly flowNodePersistenceFacade: IFlowNodePersistenceFacade;
 
-  protected readonly boundaryEventInstanceId: string;
+  protected boundaryEventInstanceId: string;
 
   constructor(
     eventAggregator: IEventAggregator,

--- a/src/runtime/flow_node_handler/boundary_event_handler/boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/boundary_event_handler.ts
@@ -1,6 +1,6 @@
 import * as uuid from 'node-uuid';
 
-import {Model, ProcessToken} from '@process-engine/persistence_api.contracts';
+import {FlowNodeInstance, Model, ProcessToken} from '@process-engine/persistence_api.contracts';
 import {
   BoundaryEventTriggeredMessage,
   IBoundaryEventHandler,
@@ -43,6 +43,15 @@ export abstract class BoundaryEventHandler implements IBoundaryEventHandler {
   }
 
   public abstract async waitForTriggeringEvent(
+    onTriggeredCallback: OnBoundaryEventTriggeredCallback,
+    token: ProcessToken,
+    processTokenFacade: IProcessTokenFacade,
+    processModelFacade: IProcessModelFacade,
+    attachedFlowNodeInstanceId: string,
+  ): Promise<void>;
+
+  public abstract async resumeWait(
+    boundaryEventInstance: FlowNodeInstance,
     onTriggeredCallback: OnBoundaryEventTriggeredCallback,
     token: ProcessToken,
     processTokenFacade: IProcessTokenFacade,

--- a/src/runtime/flow_node_handler/boundary_event_handler/boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/boundary_event_handler.ts
@@ -31,7 +31,7 @@ export abstract class BoundaryEventHandler implements IBoundaryEventHandler {
   protected readonly flowNodePersistenceFacade: IFlowNodePersistenceFacade;
 
   protected boundaryEventInstanceId: string;
-  protected boundaryEventInstance?: FlowNodeInstance; // Only set during FlowNode resumption.
+  private flowNodeInstance?: FlowNodeInstance; // Only set during FlowNode resumption.
 
   constructor(
     eventAggregator: IEventAggregator,
@@ -42,6 +42,11 @@ export abstract class BoundaryEventHandler implements IBoundaryEventHandler {
     this.boundaryEventModel = boundaryEventModel;
     this.boundaryEventInstanceId = uuid.v4();
     this.eventAggregator = eventAggregator;
+  }
+
+  protected set boundaryEventInstance(flowNodeInstance: FlowNodeInstance) {
+    this.flowNodeInstance = flowNodeInstance;
+    this.boundaryEventInstanceId = flowNodeInstance.id;
   }
 
   public getInstanceId(): string {
@@ -66,7 +71,7 @@ export abstract class BoundaryEventHandler implements IBoundaryEventHandler {
   ): Promise<void>;
 
   public async cancel(processToken: ProcessToken, processModelFacade: IProcessModelFacade): Promise<void> {
-    if (this.boundaryEventInstance?.state !== FlowNodeInstanceState.running) {
+    if (this.boundaryEventInstance?.state === FlowNodeInstanceState.finished) {
       return;
     }
     await this.persistOnExit(processToken);

--- a/src/runtime/flow_node_handler/boundary_event_handler/boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/boundary_event_handler.ts
@@ -66,9 +66,10 @@ export abstract class BoundaryEventHandler implements IBoundaryEventHandler {
   ): Promise<void>;
 
   public async cancel(processToken: ProcessToken, processModelFacade: IProcessModelFacade): Promise<void> {
-    if (this.boundaryEventInstance?.state === FlowNodeInstanceState.running) {
-      await this.persistOnExit(processToken);
+    if (this.boundaryEventInstance?.state !== FlowNodeInstanceState.running) {
+      return;
     }
+    await this.persistOnExit(processToken);
   }
 
   public getNextFlowNode(processModelFacade: IProcessModelFacade): Model.Base.FlowNode {

--- a/src/runtime/flow_node_handler/boundary_event_handler/error_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/error_boundary_event_handler.ts
@@ -64,7 +64,7 @@ export class ErrorBoundaryEventHandler extends BoundaryEventHandler {
     attachedFlowNodeInstanceId: string,
   ): Promise<void> {
 
-    this.boundaryEventInstanceId = boundaryEventInstance.id;
+    this.boundaryEventInstance = boundaryEventInstance;
     this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
   }
 

--- a/src/runtime/flow_node_handler/boundary_event_handler/error_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/error_boundary_event_handler.ts
@@ -1,4 +1,4 @@
-import {ProcessToken} from '@process-engine/persistence_api.contracts';
+import {FlowNodeInstance, ProcessToken} from '@process-engine/persistence_api.contracts';
 import {
   BpmnError,
   IProcessModelFacade,
@@ -53,6 +53,18 @@ export class ErrorBoundaryEventHandler extends BoundaryEventHandler {
     }
     await this.persistOnEnter(token);
 
+    this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
+  }
+
+  public async resumeWait(
+    boundaryEventInstance: FlowNodeInstance,
+    onTriggeredCallback: OnBoundaryEventTriggeredCallback,
+    token: ProcessToken, processTokenFacade: IProcessTokenFacade,
+    processModelFacade: IProcessModelFacade,
+    attachedFlowNodeInstanceId: string,
+  ): Promise<void> {
+
+    this.boundaryEventInstanceId = boundaryEventInstance.id;
     this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
   }
 

--- a/src/runtime/flow_node_handler/boundary_event_handler/message_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/message_boundary_event_handler.ts
@@ -1,6 +1,6 @@
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
 
-import {ProcessToken} from '@process-engine/persistence_api.contracts';
+import {FlowNodeInstance, ProcessToken} from '@process-engine/persistence_api.contracts';
 import {
   IProcessModelFacade,
   IProcessTokenFacade,
@@ -25,11 +25,36 @@ export class MessageBoundaryEventHandler extends BoundaryEventHandler {
 
     this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
 
+    await this.persistOnEnter(token);
+
+    this.waitForMessage(onTriggeredCallback, token, processModelFacade);
+  }
+
+  public async resumeWait(
+    boundaryEventInstance: FlowNodeInstance,
+    onTriggeredCallback: OnBoundaryEventTriggeredCallback,
+    token: ProcessToken,
+    processTokenFacade: IProcessTokenFacade,
+    processModelFacade: IProcessModelFacade,
+    attachedFlowNodeInstanceId: string,
+  ): Promise<void> {
+
+    this.boundaryEventInstanceId = boundaryEventInstance.id;
+    this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
+
+    this.waitForMessage(onTriggeredCallback, token, processModelFacade);
+  }
+
+  private waitForMessage(
+    onTriggeredCallback: OnBoundaryEventTriggeredCallback,
+    token: ProcessToken,
+    processModelFacade: IProcessModelFacade,
+  ): void {
+
     const laneContainingCurrentFlowNode = processModelFacade.getLaneForFlowNode(this.boundaryEventModel.id);
     if (laneContainingCurrentFlowNode != undefined) {
       token.currentLane = laneContainingCurrentFlowNode.name;
     }
-    await this.persistOnEnter(token);
 
     const messageBoundaryEventName = eventAggregatorSettings.messagePaths.messageEventReached
       .replace(eventAggregatorSettings.messageParams.messageReference, this.boundaryEventModel.messageEventDefinition.name);

--- a/src/runtime/flow_node_handler/boundary_event_handler/message_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/message_boundary_event_handler.ts
@@ -45,6 +45,11 @@ export class MessageBoundaryEventHandler extends BoundaryEventHandler {
     this.waitForMessage(onTriggeredCallback, token, processModelFacade);
   }
 
+  public async cancel(token: ProcessToken, processModelFacade: IProcessModelFacade): Promise<void> {
+    await super.cancel(token, processModelFacade);
+    this.eventAggregator.unsubscribe(this.subscription);
+  }
+
   private waitForMessage(
     onTriggeredCallback: OnBoundaryEventTriggeredCallback,
     token: ProcessToken,
@@ -80,11 +85,6 @@ export class MessageBoundaryEventHandler extends BoundaryEventHandler {
     this.subscription = this.boundaryEventModel.cancelActivity
       ? this.eventAggregator.subscribeOnce(messageBoundaryEventName, messageReceivedCallback)
       : this.eventAggregator.subscribe(messageBoundaryEventName, messageReceivedCallback);
-  }
-
-  public async cancel(token: ProcessToken, processModelFacade: IProcessModelFacade): Promise<void> {
-    await super.cancel(token, processModelFacade);
-    this.eventAggregator.unsubscribe(this.subscription);
   }
 
 }

--- a/src/runtime/flow_node_handler/boundary_event_handler/message_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/message_boundary_event_handler.ts
@@ -39,7 +39,7 @@ export class MessageBoundaryEventHandler extends BoundaryEventHandler {
     attachedFlowNodeInstanceId: string,
   ): Promise<void> {
 
-    this.boundaryEventInstanceId = boundaryEventInstance.id;
+    this.boundaryEventInstance = boundaryEventInstance;
     this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
 
     this.waitForMessage(onTriggeredCallback, token, processModelFacade);

--- a/src/runtime/flow_node_handler/boundary_event_handler/signal_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/signal_boundary_event_handler.ts
@@ -39,7 +39,7 @@ export class SignalBoundaryEventHandler extends BoundaryEventHandler {
     attachedFlowNodeInstanceId: string,
   ): Promise<void> {
 
-    this.boundaryEventInstanceId = boundaryEventInstance.id;
+    this.boundaryEventInstance = boundaryEventInstance;
     this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
 
     this.waitForSignal(onTriggeredCallback, token, processModelFacade);

--- a/src/runtime/flow_node_handler/boundary_event_handler/signal_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/signal_boundary_event_handler.ts
@@ -45,6 +45,11 @@ export class SignalBoundaryEventHandler extends BoundaryEventHandler {
     this.waitForSignal(onTriggeredCallback, token, processModelFacade);
   }
 
+  public async cancel(token: ProcessToken, processModelFacade: IProcessModelFacade): Promise<void> {
+    await super.cancel(token, processModelFacade);
+    this.eventAggregator.unsubscribe(this.subscription);
+  }
+
   private waitForSignal(
     onTriggeredCallback: OnBoundaryEventTriggeredCallback,
     token: ProcessToken,
@@ -80,11 +85,6 @@ export class SignalBoundaryEventHandler extends BoundaryEventHandler {
     this.subscription = this.boundaryEventModel.cancelActivity
       ? this.eventAggregator.subscribeOnce(signalBoundaryEventName, signalReceivedCallback)
       : this.eventAggregator.subscribe(signalBoundaryEventName, signalReceivedCallback);
-  }
-
-  public async cancel(token: ProcessToken, processModelFacade: IProcessModelFacade): Promise<void> {
-    await super.cancel(token, processModelFacade);
-    this.eventAggregator.unsubscribe(this.subscription);
   }
 
 }

--- a/src/runtime/flow_node_handler/boundary_event_handler/signal_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/signal_boundary_event_handler.ts
@@ -1,6 +1,6 @@
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
 
-import {ProcessToken} from '@process-engine/persistence_api.contracts';
+import {FlowNodeInstance, ProcessToken} from '@process-engine/persistence_api.contracts';
 import {
   IProcessModelFacade,
   IProcessTokenFacade,
@@ -25,11 +25,36 @@ export class SignalBoundaryEventHandler extends BoundaryEventHandler {
 
     this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
 
+    await this.persistOnEnter(token);
+
+    this.waitForSignal(onTriggeredCallback, token, processModelFacade);
+  }
+
+  public async resumeWait(
+    boundaryEventInstance: FlowNodeInstance,
+    onTriggeredCallback: OnBoundaryEventTriggeredCallback,
+    token: ProcessToken,
+    processTokenFacade: IProcessTokenFacade,
+    processModelFacade: IProcessModelFacade,
+    attachedFlowNodeInstanceId: string,
+  ): Promise<void> {
+
+    this.boundaryEventInstanceId = boundaryEventInstance.id;
+    this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
+
+    this.waitForSignal(onTriggeredCallback, token, processModelFacade);
+  }
+
+  private waitForSignal(
+    onTriggeredCallback: OnBoundaryEventTriggeredCallback,
+    token: ProcessToken,
+    processModelFacade: IProcessModelFacade,
+  ): void {
+
     const laneContainingCurrentFlowNode = processModelFacade.getLaneForFlowNode(this.boundaryEventModel.id);
     if (laneContainingCurrentFlowNode != undefined) {
       token.currentLane = laneContainingCurrentFlowNode.name;
     }
-    await this.persistOnEnter(token);
 
     const signalBoundaryEventName = eventAggregatorSettings.messagePaths.signalEventReached
       .replace(eventAggregatorSettings.messageParams.signalReference, this.boundaryEventModel.signalEventDefinition.name);

--- a/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
@@ -72,8 +72,8 @@ export class TimerBoundaryEventHandler extends BoundaryEventHandler {
   }
 
   public async cancel(token: ProcessToken, processModelFacade: IProcessModelFacade): Promise<void> {
-    await super.cancel(token, processModelFacade);
     this.timerFacade.cancelTimerSubscription(this.timerSubscription);
+    await super.cancel(token, processModelFacade);
   }
 
 }

--- a/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
@@ -39,14 +39,44 @@ export class TimerBoundaryEventHandler extends BoundaryEventHandler {
     attachedFlowNodeInstanceId: string,
   ): Promise<void> {
 
-    this.logger.verbose(`Initializing TimerBoundaryEvent for ProcessModel ${token.processModelId} in ProcessInstance ${token.processInstanceId}`);
+    this.logger.verbose(`Initializing BoundaryEvent on FlowNodeInstance ${attachedFlowNodeInstanceId} in ProcessInstance ${token.processInstanceId}`);
     this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
+
+    await this.persistOnEnter(token);
+
+    this.initializeTimer(onTriggeredCallback, token, processTokenFacade, processModelFacade);
+  }
+
+  public async resumeWait(
+    onTriggeredCallback: OnBoundaryEventTriggeredCallback,
+    token: ProcessToken,
+    processTokenFacade: IProcessTokenFacade,
+    processModelFacade: IProcessModelFacade,
+    attachedFlowNodeInstanceId: string,
+  ): Promise<void> {
+
+    this.logger.verbose(`Resuming BoundaryEvent on FlowNodeInstance ${attachedFlowNodeInstanceId} in ProcessInstance ${token.processInstanceId}`);
+    this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
+
+    this.initializeTimer(onTriggeredCallback, token, processTokenFacade, processModelFacade);
+  }
+
+  public async cancel(token: ProcessToken, processModelFacade: IProcessModelFacade): Promise<void> {
+    this.timerFacade.cancelTimerSubscription(this.timerSubscription);
+    await super.cancel(token, processModelFacade);
+  }
+
+  private initializeTimer(
+    onTriggeredCallback: OnBoundaryEventTriggeredCallback,
+    token: ProcessToken,
+    processTokenFacade: IProcessTokenFacade,
+    processModelFacade: IProcessModelFacade,
+  ): void {
 
     const laneContainingCurrentFlowNode = processModelFacade.getLaneForFlowNode(this.boundaryEventModel.id);
     if (laneContainingCurrentFlowNode != undefined) {
       token.currentLane = laneContainingCurrentFlowNode.name;
     }
-    await this.persistOnEnter(token);
 
     const timerElapsed = async (): Promise<void> => {
 
@@ -69,11 +99,6 @@ export class TimerBoundaryEventHandler extends BoundaryEventHandler {
     this.timerSubscription = this
       .timerFacade
       .initializeTimer(this.boundaryEventModel, this.boundaryEventModel.timerEventDefinition, processTokenFacade, timerElapsed);
-  }
-
-  public async cancel(token: ProcessToken, processModelFacade: IProcessModelFacade): Promise<void> {
-    this.timerFacade.cancelTimerSubscription(this.timerSubscription);
-    await super.cancel(token, processModelFacade);
   }
 
 }

--- a/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
@@ -2,7 +2,7 @@ import {Logger} from 'loggerhythm';
 
 import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
 
-import {Model, ProcessToken} from '@process-engine/persistence_api.contracts';
+import {FlowNodeInstance, Model, ProcessToken} from '@process-engine/persistence_api.contracts';
 import {
   IFlowNodePersistenceFacade,
   IProcessModelFacade,
@@ -48,6 +48,7 @@ export class TimerBoundaryEventHandler extends BoundaryEventHandler {
   }
 
   public async resumeWait(
+    boundaryEventInstance: FlowNodeInstance,
     onTriggeredCallback: OnBoundaryEventTriggeredCallback,
     token: ProcessToken,
     processTokenFacade: IProcessTokenFacade,
@@ -56,6 +57,8 @@ export class TimerBoundaryEventHandler extends BoundaryEventHandler {
   ): Promise<void> {
 
     this.logger.verbose(`Resuming BoundaryEvent on FlowNodeInstance ${attachedFlowNodeInstanceId} in ProcessInstance ${token.processInstanceId}`);
+
+    this.boundaryEventInstanceId = boundaryEventInstance.id;
     this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
 
     this.initializeTimer(onTriggeredCallback, token, processTokenFacade, processModelFacade);

--- a/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
@@ -58,7 +58,7 @@ export class TimerBoundaryEventHandler extends BoundaryEventHandler {
 
     this.logger.verbose(`Resuming BoundaryEvent on FlowNodeInstance ${attachedFlowNodeInstanceId} in ProcessInstance ${token.processInstanceId}`);
 
-    this.boundaryEventInstanceId = boundaryEventInstance.id;
+    this.boundaryEventInstance = boundaryEventInstance;
     this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
 
     this.initializeTimer(onTriggeredCallback, token, processTokenFacade, processModelFacade);


### PR DESCRIPTION
## Changes

1. Detach BoundaryEvents prior to running `afterExecute` cleanup on decorated Activities
2. Implement resumption for BoundaryEventHandlers
3. When resuming a decorated activity, all attached BoundaryEvents will now be resumed, instead of executed
    - This fixes the issue with multiple `onEnter` tokens for a single BoundaryEvent
4. Fix some reference issues
5. Unsubscribe from `ExternalTaskFinished` event, when an `ExternalServiceTaskHandler` gets interruped
6. Fix finishing of BoundaryEvents
    - Each BoundaryEvent should now always produce an `onExit` token, either when trigger, or when the activity finishes and removes its BoundaryEvents
7. Refine resumption of ProcessInstances. A ProcessInstance is now considered to be orphaned, if it:
    - is in a running state
    - has no active FlowNodeInstances
    - has reached at least one EndEvent
8. ProcessInstances that were in a running state, have no active FlowNodeInstances, but have not yet reached an EndEvent are regarded as interrupted and will be resumed regularly.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/510

PR: #318

## How to test the changes

To check the BoundaryEvents:

- Run a Process that uses decorated activities
    - easiest would be a UserTask or an external ServiceTask because they do not automatically resume
- Decorate these activities with either:
    - `TimerBoundaryEvent`
    - `MessageBoundaryEvent`
    - `SignalBoundaryEvent`
- Trigger the BoundaryEvent 
    - Messages and Signals can be easily triggered through a separate process that uses IntermediateEvents or dedicated EndEvents
- See that the decorated activity cancels execution
- See that the process now follows the path marked by the BoundaryEvent
- See that the BoundaryEvent instance has produced only one `onEnter` and one `onExit` token

To check the resumption of ProcessInstances:

**Note:** The changes described in the following steps have to be performed manually in your database.

1.
- Run a ProcessInstance and finish it (A ProcessModel with StartEvent -> ScriptTask -> EndEvent is sufficient for this)
- Change the state of the ProcessInstance to running
- Manually remove the FlowNodeInstance of the EndEvent
- Change the state of the ScriptTask to "running" and remove the "onExit" token
- The ProcessInstance will be resumed until the EndEvent is reached

2.
- Run a ProcessInstance and finish it
- Change the state of the ProcessInstance to running
- Manually remove the FlowNodeInstance of the EndEvent
- Do NOT modify any of the other FlowNodeInstances
- The ProcessInstance will be resumed until the EndEvent is reached

3.
- Run a ProcessInstance and finish it
- Change the state of the ProcessInstance to running
- Do NOT modify any of the FlowNodeInstances
- The ProcessInstance will be regared as orphaned. It will be put into a "finished" state