### PR TITLE
♻️ Add async locks for gateways

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/clone": "^0.1.30",
     "@types/socket.io": "^2.1.2",
     "addict-ioc": "^2.5.1",
+    "async-lock": "^1.2.2",
     "bluebird": "^3.5.2",
     "bluebird-global": "^1.0.1",
     "clone": "^2.1.2",

--- a/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/activity_handler.ts
@@ -91,17 +91,6 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
               identity,
             );
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
-
-            // NOTE:
-            // This is a workaround for a problem with the resumption of multiple parallel branches that were executed right up to the JoinGateway.
-            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible
-            // that multiple instances for that same Gateway are created.
-            // Since the Gateway always waits for ALL incoming branches before moving on,
-            // this will result in the process instance getting stuck forever.
-            // Using a timeout helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
-            if (nextFlowNodes.length > 1) {
-              await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 33));
-            }
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);
@@ -190,11 +179,6 @@ export abstract class ActivityHandler<TFlowNode extends Model.Base.FlowNode> ext
               allFlowNodeInstances,
             );
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
-
-            // See above
-            if (nextFlowNodes.length > 1) {
-              await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 33));
-            }
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);

--- a/src/runtime/flow_node_handler/event_handler/event_handler.ts
+++ b/src/runtime/flow_node_handler/event_handler/event_handler.ts
@@ -82,17 +82,6 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
               identity,
             );
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
-
-            // NOTE:
-            // This is a workaround for a problem with the resumption of multiple parallel branches that were executed right up to the JoinGateway.
-            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible
-            // that multiple instances for that same Gateway are created.
-            // Since the Gateway always waits for ALL incoming branches before moving on,
-            // this will result in the process instance getting stuck forever.
-            // Using a timeout helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
-            if (nextFlowNodes.length > 1) {
-              await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 33));
-            }
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);
@@ -158,11 +147,6 @@ export abstract class EventHandler<TFlowNode extends Model.Base.FlowNode> extend
               allFlowNodeInstances,
             );
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
-
-            // See above
-            if (nextFlowNodes.length > 1) {
-              await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 33));
-            }
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -68,7 +68,7 @@ export abstract class GatewayHandler<TFlowNode extends Model.Gateways.Gateway> e
 
       try {
         let nextFlowNodes: Array<Model.Base.FlowNode>;
-        await lock.acquire<Array<Model.Base.FlowNode>>(this.flowNode.id, async () => {
+        await lock.acquire<Array<Model.Base.FlowNode>>(this.flowNodeInstanceId, async () => {
           await this.beforeExecute(token, processTokenFacade, processModelFacade, identity, reject);
           nextFlowNodes = await this.startExecution(token, processTokenFacade, processModelFacade, identity);
           await this.afterExecute(token, processTokenFacade, processModelFacade, identity);
@@ -141,7 +141,7 @@ export abstract class GatewayHandler<TFlowNode extends Model.Gateways.Gateway> e
 
       try {
         let nextFlowNodes: Array<Model.Base.FlowNode>;
-        await lock.acquire<Array<Model.Base.FlowNode>>(this.flowNode.id, async () => {
+        await lock.acquire<Array<Model.Base.FlowNode>>(this.flowNodeInstanceId, async () => {
           await this.beforeExecute(token, processTokenFacade, processModelFacade, identity, reject);
           nextFlowNodes = await this.resumeFromState(flowNodeInstanceForHandler, processTokenFacade, processModelFacade, identity);
           await this.afterExecute(token, processTokenFacade, processModelFacade, identity);

--- a/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
+++ b/src/runtime/flow_node_handler/gateway_handler/gateway_handler.ts
@@ -98,17 +98,6 @@ export abstract class GatewayHandler<TFlowNode extends Model.Gateways.Gateway> e
               identity,
             );
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
-
-            // NOTE:
-            // This is a workaround for a problem with the resumption of multiple parallel branches that were executed right up to the JoinGateway.
-            // When multiple branches arrive at the JoinGateway at the EXACT same moment, it is possible
-            // that multiple instances for that same Gateway are created.
-            // Since the Gateway always waits for ALL incoming branches before moving on,
-            // this will result in the process instance getting stuck forever.
-            // Using a timeout helps us to get around this issue, but it is just a hacky workaround. We need a more permanent solution for this.
-            if (nextFlowNodes.length > 1) {
-              await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 33));
-            }
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);
@@ -178,11 +167,6 @@ export abstract class GatewayHandler<TFlowNode extends Model.Gateways.Gateway> e
               allFlowNodeInstances,
             );
             nextFlowNodeExecutionPromises.push(handleNextFlowNodePromise);
-
-            // See above
-            if (nextFlowNodes.length > 1) {
-              await new Promise((cb): NodeJS.Timeout => setTimeout(cb, 33));
-            }
           }
 
           await Promise.all(nextFlowNodeExecutionPromises);


### PR DESCRIPTION
## Changes

1. GatewayHandlers now wrap their `execute` hooks into an async lock. 
    - This is done to prevent race conditions during Join Gateway execution (See references issue).
2. Remove timeout used as workaround from base handlers 
 
## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/523

PR: #322

## How to test the changes

- Create a process that makes use of ParallelGateways - ideally with 3+ branches
    - Best use tasks that can be finished simultaneously for each branch (like ExternalServiceTasks with the same topic)
-  Run that process 4-5 times
- When all ExternalTasks have been created, start a Worker that can process these tasks simultaenously
- Note that all FlowNodes of each ProcessInstance will be finished correctly