### PR TITLE
🐛 Fix resumption of activities that followed a triggered BoundaryEvent

### DIFF
--- a/src/runtime/flow_node_handler/boundary_event_handler/boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/boundary_event_handler.ts
@@ -82,7 +82,9 @@ export abstract class BoundaryEventHandler implements IBoundaryEventHandler {
     return processModelFacade.getNextFlowNodesFor(this.boundaryEventModel).pop();
   }
 
-  protected async persistOnEnter(processToken: ProcessToken): Promise<void> {
+  protected async persistOnEnter(processToken: ProcessToken, decoratedFlowNodeInstanceId: string): Promise<void> {
+    this.attachedFlowNodeInstanceId = decoratedFlowNodeInstanceId;
+
     await this
       .flowNodePersistenceFacade
       .persistOnEnter(this.boundaryEventModel, this.boundaryEventInstanceId, processToken, this.attachedFlowNodeInstanceId);

--- a/src/runtime/flow_node_handler/boundary_event_handler/error_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/error_boundary_event_handler.ts
@@ -51,9 +51,7 @@ export class ErrorBoundaryEventHandler extends BoundaryEventHandler {
     if (laneContainingCurrentFlowNode != undefined) {
       token.currentLane = laneContainingCurrentFlowNode.name;
     }
-    await this.persistOnEnter(token);
-
-    this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
+    await this.persistOnEnter(token, attachedFlowNodeInstanceId);
   }
 
   public async resumeWait(

--- a/src/runtime/flow_node_handler/boundary_event_handler/message_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/message_boundary_event_handler.ts
@@ -23,9 +23,7 @@ export class MessageBoundaryEventHandler extends BoundaryEventHandler {
     attachedFlowNodeInstanceId: string,
   ): Promise<void> {
 
-    this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
-
-    await this.persistOnEnter(token);
+    await this.persistOnEnter(token, attachedFlowNodeInstanceId);
 
     this.waitForMessage(onTriggeredCallback, token, processModelFacade);
   }

--- a/src/runtime/flow_node_handler/boundary_event_handler/message_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/message_boundary_event_handler.ts
@@ -1,7 +1,10 @@
-import {Subscription} from '@essential-projects/event_aggregator_contracts';
+import {Logger} from 'loggerhythm';
 
-import {FlowNodeInstance, ProcessToken} from '@process-engine/persistence_api.contracts';
+import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
+
+import {FlowNodeInstance, Model, ProcessToken} from '@process-engine/persistence_api.contracts';
 import {
+  IFlowNodePersistenceFacade,
   IProcessModelFacade,
   IProcessTokenFacade,
   MessageEventReachedMessage,
@@ -13,7 +16,18 @@ import {BoundaryEventHandler} from './boundary_event_handler';
 
 export class MessageBoundaryEventHandler extends BoundaryEventHandler {
 
+  private readonly logger: Logger;
+
   private subscription: Subscription;
+
+  constructor(
+    eventAggregator: IEventAggregator,
+    flowNodePersistenceFacade: IFlowNodePersistenceFacade,
+    boundaryEventModel: Model.Events.BoundaryEvent,
+  ) {
+    super(eventAggregator, flowNodePersistenceFacade, boundaryEventModel);
+    this.logger = new Logger(`processengine:timer_boundary_event_handler:${boundaryEventModel.id}`);
+  }
 
   public async waitForTriggeringEvent(
     onTriggeredCallback: OnBoundaryEventTriggeredCallback,
@@ -23,6 +37,7 @@ export class MessageBoundaryEventHandler extends BoundaryEventHandler {
     attachedFlowNodeInstanceId: string,
   ): Promise<void> {
 
+    this.logger.verbose(`Initializing BoundaryEvent on FlowNodeInstance ${attachedFlowNodeInstanceId} in ProcessInstance ${token.processInstanceId}`);
     await this.persistOnEnter(token, attachedFlowNodeInstanceId);
 
     this.waitForMessage(onTriggeredCallback, token, processModelFacade);
@@ -36,6 +51,8 @@ export class MessageBoundaryEventHandler extends BoundaryEventHandler {
     processModelFacade: IProcessModelFacade,
     attachedFlowNodeInstanceId: string,
   ): Promise<void> {
+
+    this.logger.verbose(`Resuming BoundaryEvent on FlowNodeInstance ${attachedFlowNodeInstanceId} in ProcessInstance ${token.processInstanceId}`);
 
     this.boundaryEventInstance = boundaryEventInstance;
     this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;

--- a/src/runtime/flow_node_handler/boundary_event_handler/signal_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/signal_boundary_event_handler.ts
@@ -23,9 +23,7 @@ export class SignalBoundaryEventHandler extends BoundaryEventHandler {
     attachedFlowNodeInstanceId: string,
   ): Promise<void> {
 
-    this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
-
-    await this.persistOnEnter(token);
+    await this.persistOnEnter(token, attachedFlowNodeInstanceId);
 
     this.waitForSignal(onTriggeredCallback, token, processModelFacade);
   }

--- a/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
+++ b/src/runtime/flow_node_handler/boundary_event_handler/timer_boundary_event_handler.ts
@@ -40,9 +40,7 @@ export class TimerBoundaryEventHandler extends BoundaryEventHandler {
   ): Promise<void> {
 
     this.logger.verbose(`Initializing BoundaryEvent on FlowNodeInstance ${attachedFlowNodeInstanceId} in ProcessInstance ${token.processInstanceId}`);
-    this.attachedFlowNodeInstanceId = attachedFlowNodeInstanceId;
-
-    await this.persistOnEnter(token);
+    await this.persistOnEnter(token, attachedFlowNodeInstanceId);
 
     this.initializeTimer(onTriggeredCallback, token, processTokenFacade, processModelFacade);
   }


### PR DESCRIPTION
## Changes

1. Fix creation of FlowNodeHandlers for FlowNodeInstances that followed a triggered BoundaryEvent
2. Fix null-value issue with `previousFlowNodeInstanceId` on BoundaryEventInstances
3. Robustify discovery of FlowNodeInstances that followed a triggered BoundaryEvent (improved early exit)
4. Use Bluebird.map instead of Promise.map to avoid reference errors, in case Bluebird is not the default Promise library of the hosting application

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/544

PR: #326

## How to test the changes

See the reproduction steps described in the issue.