### PR TITLE
🐛 Fix the wrong subscription message path

### DIFF
--- a/src/runtime/flow_node_handler/activity_handler/call_activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/call_activity_handler.ts
@@ -264,7 +264,7 @@ export class CallActivityHandler extends ActivityHandler<Model.Activities.CallAc
 
       const processEndMessageName = eventAggregatorSettings.messagePaths.endEventReached
         .replace(eventAggregatorSettings.messageParams.correlationId, result.correlationId)
-        .replace(eventAggregatorSettings.messageParams.processModelId, token.processModelId);
+        .replace(eventAggregatorSettings.messageParams.processModelId, result.processModelId);
 
       this.subProcessEndedSubscription = this.eventAggregator.subscribe(processEndMessageName, (message) => {
         if (message.processInstanceId === this.subProcessInstanceId) {

--- a/src/runtime/flow_node_handler/activity_handler/call_activity_handler.ts
+++ b/src/runtime/flow_node_handler/activity_handler/call_activity_handler.ts
@@ -262,15 +262,17 @@ export class CallActivityHandler extends ActivityHandler<Model.Activities.CallAc
         reject(message.currentToken);
       });
 
-      const processEndMessageName = eventAggregatorSettings.messagePaths.endEventReached.replace(
-        eventAggregatorSettings.messageParams.processInstanceId,
-        this.subProcessInstanceId,
-      );
+      const processEndMessageName = eventAggregatorSettings.messagePaths.endEventReached
+        .replace(eventAggregatorSettings.messageParams.correlationId, result.correlationId)
+        .replace(eventAggregatorSettings.messageParams.processModelId, token.processModelId);
 
-      this.subProcessEndedSubscription = this.eventAggregator.subscribeOnce(processEndMessageName, (message) => {
-        this.eventAggregator.unsubscribe(this.subProcessErroredSubscription);
-        this.eventAggregator.unsubscribe(this.subProcessTerminatedSubscription);
-        resolve(message);
+      this.subProcessEndedSubscription = this.eventAggregator.subscribe(processEndMessageName, (message) => {
+        if (message.processInstanceId === this.subProcessInstanceId) {
+          this.eventAggregator.unsubscribe(this.subProcessEndedSubscription);
+          this.eventAggregator.unsubscribe(this.subProcessErroredSubscription);
+          this.eventAggregator.unsubscribe(this.subProcessTerminatedSubscription);
+          resolve(message);
+        }
       });
 
       const processInstanceErrored = eventAggregatorSettings.messagePaths.processInstanceWithIdErrored.replace(


### PR DESCRIPTION
## Changes

1. Fix wrong subscription path for the processEndSubscription

## Issues

PR: #331


## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
